### PR TITLE
Add number_of_splits as a shortcut to splits().len()

### DIFF
--- a/src/co_grouped_rdd.rs
+++ b/src/co_grouped_rdd.rs
@@ -162,6 +162,9 @@ impl<K: Data + Eq + Hash> RddBase for CoGroupedRdd<K> {
         }
         splits
     }
+    fn number_of_splits(&self) -> usize {
+        self.part.get_num_of_partitions()
+    }
     fn partitioner(&self) -> Option<Box<dyn Partitioner>> {
         let part = self.part.clone() as Box<dyn Partitioner>;
         Some(part)

--- a/src/context.rs
+++ b/src/context.rs
@@ -299,7 +299,7 @@ impl Context {
         let cl = Fn!([func] move | (task_context, iter) | (*func)(iter));
         let func = Arc::new(cl);
         self.scheduler
-            .run_job(func, rdd.clone(), (0..rdd.splits().len()).collect(), false)
+            .run_job(func, rdd.clone(), (0..rdd.number_of_splits()).collect(), false)
     }
 
     pub fn run_job_with_context<T: Data, U: Data, RT, F>(&mut self, rdd: Arc<RT>, func: F) -> Vec<U>
@@ -316,6 +316,6 @@ impl Context {
         info!("inside run job in context");
         let func = Arc::new(func);
         self.scheduler
-            .run_job(func, rdd.clone(), (0..rdd.splits().len()).collect(), false)
+            .run_job(func, rdd.clone(), (0..rdd.number_of_splits()).collect(), false)
     }
 }

--- a/src/distributed_scheduler.rs
+++ b/src/distributed_scheduler.rs
@@ -170,12 +170,12 @@ impl DistributedScheduler {
         info!("inside new stage");
         env::env
             .cache_tracker
-            .register_rdd(rdd_base.get_rdd_id(), rdd_base.splits().len());
+            .register_rdd(rdd_base.get_rdd_id(), rdd_base.number_of_splits());
         if !shuffle_dependency.is_none() {
             info!("shuffle dependcy and registering mapoutput tracker");
             self.map_output_tracker.register_shuffle(
                 shuffle_dependency.clone().unwrap().get_shuffle_id(),
-                rdd_base.splits().len(),
+                rdd_base.number_of_splits(),
             );
             info!("new stage tracker after");
         }
@@ -210,7 +210,7 @@ impl DistributedScheduler {
             visited.insert(rdd.clone());
             env::env
                 .cache_tracker
-                .register_rdd(rdd.get_rdd_id(), rdd.splits().len());
+                .register_rdd(rdd.get_rdd_id(), rdd.number_of_splits());
             for dep in rdd.get_dependencies() {
                 match dep {
                     Dependency::ShuffleDependency(shuf_dep) => {
@@ -256,7 +256,7 @@ impl DistributedScheduler {
         if !visited.contains(&rdd) {
             visited.insert(rdd.clone());
             // TODO CacheTracker register
-            for p in 0..rdd.splits().len() {
+            for p in 0..rdd.number_of_splits() {
                 let locs = self.get_cache_locs(rdd.clone());
                 info!("cache locs {:?}", locs);
                 if locs == None {

--- a/src/local_scheduler.rs
+++ b/src/local_scheduler.rs
@@ -145,12 +145,12 @@ impl LocalScheduler {
         info!("inside new stage");
         env::env
             .cache_tracker
-            .register_rdd(rdd_base.get_rdd_id(), rdd_base.splits().len());
+            .register_rdd(rdd_base.get_rdd_id(), rdd_base.number_of_splits());
         if !shuffle_dependency.is_none() {
             info!("shuffle dependcy and registering mapoutput tracker");
             self.map_output_tracker.register_shuffle(
                 shuffle_dependency.clone().unwrap().get_shuffle_id(),
-                rdd_base.splits().len(),
+                rdd_base.number_of_splits(),
             );
             info!("new stage tracker after");
         }
@@ -185,7 +185,7 @@ impl LocalScheduler {
             visited.insert(rdd.clone());
             env::env
                 .cache_tracker
-                .register_rdd(rdd.get_rdd_id(), rdd.splits().len());
+                .register_rdd(rdd.get_rdd_id(), rdd.number_of_splits());
             for dep in rdd.get_dependencies() {
                 match dep {
                     Dependency::ShuffleDependency(shuf_dep) => {
@@ -231,7 +231,7 @@ impl LocalScheduler {
         if !visited.contains(&rdd) {
             visited.insert(rdd.clone());
             // TODO CacheTracker register
-            for p in 0..rdd.splits().len() {
+            for p in 0..rdd.number_of_splits() {
                 let locs = self.get_cache_locs(rdd.clone());
                 info!("cache locs {:?}", locs);
                 if locs == None {

--- a/src/pair_rdd.rs
+++ b/src/pair_rdd.rs
@@ -308,6 +308,9 @@ where
     fn splits(&self) -> Vec<Box<dyn Split>> {
         self.prev.splits()
     }
+    fn number_of_splits(&self) -> usize {
+        self.prev.number_of_splits()
+    }
     fn iterator_any(&self, split: Box<dyn Split>) -> Box<dyn Iterator<Item = Box<dyn AnyData>>> {
         info!("inside iterator_any mapvaluesrdd",);
         Box::new(
@@ -406,6 +409,9 @@ where
     }
     fn splits(&self) -> Vec<Box<dyn Split>> {
         self.prev.splits()
+    }
+    fn number_of_splits(&self) -> usize {
+        self.prev.number_of_splits()
     }
     fn iterator_any(&self, split: Box<dyn Split>) -> Box<dyn Iterator<Item = Box<dyn AnyData>>> {
         info!("inside iterator_any flatmapvaluesrdd",);

--- a/src/parallel_collection.rs
+++ b/src/parallel_collection.rs
@@ -140,6 +140,9 @@ impl<T: Data> RddBase for ParallelCollection<T> {
             })
             .collect::<Vec<Box<dyn Split>>>()
     }
+    fn number_of_splits(&self) -> usize {
+        self.rdd_vals.splits_.len()
+    }
 
     default fn cogroup_iterator_any(
         &self,

--- a/src/rdd.rs
+++ b/src/rdd.rs
@@ -73,6 +73,9 @@ pub trait RddBase: Send + Sync + Serialize + Deserialize {
         None
     }
     fn splits(&self) -> Vec<Box<dyn Split>>;
+    fn number_of_splits(&self) -> usize {
+        self.splits().len()
+    }
     // Analyse whether this is required or not. It requires downcasting while executing tasks which could hurt performance.
     fn iterator_any(&self, split: Box<dyn Split>) -> Box<dyn Iterator<Item = Box<dyn AnyData>>>;
     fn cogroup_iterator_any(
@@ -298,6 +301,9 @@ where
     fn splits(&self) -> Vec<Box<dyn Split>> {
         self.prev.splits()
     }
+    fn number_of_splits(&self) -> usize {
+        self.prev.number_of_splits()
+    }
 
     default fn cogroup_iterator_any(
         &self,
@@ -457,6 +463,9 @@ where
     }
     fn splits(&self) -> Vec<Box<dyn Split>> {
         self.prev.splits()
+    }
+    fn number_of_splits(&self) -> usize {
+        self.prev.number_of_splits()
     }
 
     default fn cogroup_iterator_any(

--- a/src/shuffled_rdd.rs
+++ b/src/shuffled_rdd.rs
@@ -106,6 +106,9 @@ where
             .map(|x| Box::new(ShuffledRddSplit::new(x)) as Box<dyn Split>)
             .collect()
     }
+    fn number_of_splits(&self) -> usize {
+        self.part.get_num_of_partitions()
+    }
     fn partitioner(&self) -> Option<Box<dyn Partitioner>> {
         Some(self.part.clone())
     }

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -51,14 +51,14 @@ impl Stage {
     ) -> Self {
         Stage {
             id,
-            num_partitions: rdd.splits().len(),
+            num_partitions: rdd.number_of_splits(),
             is_shuffle_map: shuffle_dependency.clone().is_some(),
             shuffle_dependency,
             parents,
             rdd: rdd.clone(),
             output_locs: {
                 let mut v = Vec::new();
-                for i in 0..rdd.splits().len() {
+                for i in 0..rdd.number_of_splits() {
                     v.push(Vec::new());
                 }
                 v


### PR DESCRIPTION
 to avoid building a possibly costly Vec, when only the length is relevant