### PR TITLE
First pass of error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,6 +1328,7 @@ dependencies = [
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_traitobject 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "thiserror 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,6 +1328,7 @@ dependencies = [
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_traitobject 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "simplelog 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2235,6 +2236,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2970,6 +2989,8 @@ dependencies = [
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum term 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
+"checksum thiserror 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "9fe148fa0fc3363a27092d48f7787363ded15bb8623c5d5dd4e2e9f23e4b21bc"
+"checksum thiserror-impl 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "258da67e99e590650fa541ac6be764313d23e80cefb6846b516deb8de6b6d921"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
 "checksum thrift 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0b920f620efd279611662b1baa960b20826ba835e5f2ff7ba9718c4584a648a0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ parking_lot = { version = "0.9.0", features = ["serde"] }
 capnp = "0.9.5"
 simplelog = "0.7.4"
 log = "0.4.8"
+thiserror = "1.0"
 
 [build-dependencies]
 capnpc = "0.9.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,4 +43,4 @@ chrono = "0.4"
 serde_closure = "0.1.3"
 itertools = "0.8.0"
 parquet = "0.15.0"
-
+tempfile = "3"

--- a/examples/file_read.rs
+++ b/examples/file_read.rs
@@ -6,8 +6,8 @@ use chrono::prelude::*;
 use std::fs;
 use std::io::{BufRead, BufReader};
 
-fn main() {
-    let sc = Context::new("local");
+fn main() -> Result<()> {
+    let sc = Context::new("local")?;
     let files = fs::read_dir("csv_folder")
         .unwrap()
         .map(|x| x.unwrap().path().to_str().unwrap().to_owned())
@@ -34,4 +34,5 @@ fn main() {
     let res = avg.collect();
     println!("{:?}", &res[0]);
     sc.drop_executors();
+    Ok(())
 }

--- a/examples/groupby.rs
+++ b/examples/groupby.rs
@@ -1,8 +1,8 @@
 #![allow(where_clauses_object_safety)]
 use native_spark::*;
 
-fn main() {
-    let sc = Context::new("local");
+fn main() -> Result<()> {
+    let sc = Context::new("local")?;
     let vec = vec![
         ("x".to_string(), 1),
         ("x".to_string(), 2),
@@ -25,4 +25,5 @@ fn main() {
     let res = g.collect();
     println!("res {:?}", res);
     sc.drop_executors();
+    Ok(())
 }

--- a/examples/join.rs
+++ b/examples/join.rs
@@ -1,8 +1,8 @@
 #![allow(where_clauses_object_safety)]
 use native_spark::*;
 
-fn main() {
-    let sc = Context::new("local");
+fn main() -> Result<()> {
+    let sc = Context::new("local")?;
     let col1 = vec![
         (1, ("A".to_string(), "B".to_string())),
         (2, ("C".to_string(), "D".to_string())),
@@ -22,4 +22,5 @@ fn main() {
     let inner_joined_rdd = col2.join(col1.clone(), 4);
     let res = inner_joined_rdd.collect();
     println!("res {:?}", res);
+    Ok(())
 }

--- a/examples/make_rdd.rs
+++ b/examples/make_rdd.rs
@@ -3,13 +3,14 @@ use native_spark::*;
 #[macro_use]
 extern crate serde_closure;
 
-fn main() {
+fn main() -> Result<()> {
     // for distributed mode, use Context::new("distributed")
-    let sc = Context::new("local");
+    let sc = Context::new("local")?;
     let col = sc.make_rdd((0..10).collect::<Vec<_>>(), 32);
     //Fn! will make the closures serializable. It is necessary. use serde_closure version 0.1.3.
     let vec_iter = col.map(Fn!(|i| (0..i).collect::<Vec<_>>()));
     let res = vec_iter.collect();
     println!("{:?}", res);
     sc.drop_executors();
+    Ok(())
 }

--- a/examples/parquet_column_read.rs
+++ b/examples/parquet_column_read.rs
@@ -12,8 +12,8 @@ use std::fs;
 use std::fs::File;
 use std::path::Path;
 
-fn main() {
-    let sc = Context::new("local");
+fn main() -> Result<()> {
+    let sc = Context::new("local")?;
     let files = fs::read_dir("parquet_file_dir")
         .unwrap()
         .map(|x| x.unwrap().path().to_str().unwrap().to_owned())
@@ -26,6 +26,7 @@ fn main() {
     let res = avg.collect();
     println!("{:?}", &res[0]);
     sc.drop_executors();
+    Ok(())
 }
 
 fn read(file: String) -> Box<dyn Iterator<Item = ((i32, String, i64), (i64, f64))>> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -67,7 +67,7 @@ pub struct Context {
     next_rdd_id: Arc<AtomicUsize>,
     next_shuffle_id: Arc<AtomicUsize>,
     scheduler: Schedulers,
-    address_map: Vec<(String, usize)>,
+    address_map: Vec<(String, u16)>,
     distributed_master: bool,
 }
 
@@ -87,10 +87,10 @@ impl Context {
         match mode {
             "distributed" => {
                 //TODO proper command line argument parsing
-                let mut port = 10000;
+                let mut port: u16 = 10000;
                 let args = std::env::args().skip(1).collect::<Vec<_>>();
                 //                println!("args {:?}", args);
-                let mut address_map: Vec<(String, usize)> = Vec::new();
+                let mut address_map: Vec<(String, u16)> = Vec::new();
                 match args.get(0).as_ref().map(|arg| &arg[..]) {
                     Some("slave") => {
                         let uuid = Uuid::new_v4().to_string();

--- a/src/context.rs
+++ b/src/context.rs
@@ -114,7 +114,7 @@ impl Context {
                                 Config::default(),
                                 TerminalMode::Mixed,
                             )
-                            .expect("not able to create term logger"),
+                            .ok_or(Error::CreateTerminalLogger)?,
                             WriteLogger::new(
                                 LevelFilter::Info,
                                 Config::default(),
@@ -192,7 +192,7 @@ impl Context {
                 let uuid = Uuid::new_v4().to_string();
                 let _ = CombinedLogger::init(vec![
                     TermLogger::new(LevelFilter::Info, Config::default(), TerminalMode::Mixed)
-                        .expect("not able to create term logger"),
+                        .ok_or(Error::CreateTerminalLogger)?,
                     WriteLogger::new(
                         LevelFilter::Info,
                         Config::default(),

--- a/src/context.rs
+++ b/src/context.rs
@@ -100,7 +100,7 @@ impl Context {
                                 LevelFilter::Info,
                                 Config::default(),
                                 File::create(format!("/tmp/executor-{}", uuid))
-                                    .expect("not able to create log file"),
+                                    .map_err(Error::CreateLogFile)?,
                             ),
                         ]);
                         info!("started client");
@@ -134,7 +134,7 @@ impl Context {
                                 LevelFilter::Info,
                                 Config::default(),
                                 File::create(format!("/tmp/master-{}", uuid))
-                                    .expect("not able to create log file"),
+                                    .map_err(Error::CreateLogFile)?,
                             ),
                         ]);
                         let mut host_file =
@@ -221,7 +221,7 @@ impl Context {
                         LevelFilter::Info,
                         Config::default(),
                         File::create(format!("/tmp/master-{}", uuid))
-                            .expect("not able to create log file"),
+                            .map_err(Error::CreateLogFile)?,
                     ),
                 ]);
                 let scheduler = Local(LocalScheduler::new(num_cpus::get(), 20, true));

--- a/src/context.rs
+++ b/src/context.rs
@@ -135,7 +135,7 @@ impl Context {
                             let address_cli = address
                                 .split('@')
                                 .nth(1)
-                                .expect("format of address is wrong")
+                                .ok_or(Error::ParseSlaveAddress(address.into()))?
                                 .to_string();
                             address_map.push((address_cli, port));
                             let local_dir_root = "/tmp";

--- a/src/context.rs
+++ b/src/context.rs
@@ -128,7 +128,7 @@ impl Context {
                                 .map_err(|_| Error::CurrentBinaryPath)?
                                 .into_os_string()
                                 .into_string()
-                                .expect("couldn't convert os_string to string");
+                                .map_err(Error::OsStringToString)?;
                             //                            let path = path.split(" ").collect::<Vec<_>>();
                             //                            let path = path.join("\\ ");
                             //                            println!("{} {:?} slave", address, path);

--- a/src/context.rs
+++ b/src/context.rs
@@ -147,7 +147,10 @@ impl Context {
                             let mkdir_output = Command::new("ssh")
                                 .args(&[address, "mkdir", &local_dir.clone()])
                                 .output()
-                                .expect("ls command failed to start");
+                                .map_err(|e| Error::CommandOutput {
+                                    source: e,
+                                    command: "ssh mkdir".into(),
+                                })?;
                             //                            println!("mkdir output {:?}", mkdir_output);
 
                             let binary_name: Vec<_> = path.split('/').collect();
@@ -161,13 +164,19 @@ impl Context {
                             let scp_output = Command::new("scp")
                                 .args(&[&path, &remote_path])
                                 .output()
-                                .expect("ls command failed to start");
+                                .map_err(|e| Error::CommandOutput {
+                                    source: e,
+                                    command: "scp executor".into(),
+                                })?;
                             let path = format!("{}/{}", local_dir, binary_name);
                             info!("remote path {}", path);
                             Command::new("ssh")
                                 .args(&[address, &path, &"slave".to_string(), &port.to_string()])
                                 .spawn()
-                                .expect("ls command failed to start");
+                                .map_err(|e| Error::CommandOutput {
+                                    source: e,
+                                    command: "ssh run".into(),
+                                })?;
                             port += 5000;
                         }
                         Ok(Context {

--- a/src/distributed_scheduler.rs
+++ b/src/distributed_scheduler.rs
@@ -20,8 +20,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread;
 use std::time;
-//use std::time::Duration;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 use threadpool::ThreadPool;
 
 //just for now, creating an entire scheduler functions without dag scheduler trait. Later change it to extend from dag scheduler
@@ -31,7 +30,7 @@ pub struct DistributedScheduler {
     max_failures: usize,
     attempt_id: Arc<AtomicUsize>,
     resubmit_timeout: u128,
-    poll_timeout: i64,
+    poll_timeout: u64,
     event_queues: Arc<Mutex<HashMap<usize, VecDeque<CompletionEvent>>>>,
     next_job_id: Arc<AtomicUsize>,
     next_run_id: Arc<AtomicUsize>,
@@ -332,7 +331,7 @@ impl DistributedScheduler {
         let mut running: BTreeSet<Stage> = BTreeSet::new();
         let mut failed: BTreeSet<Stage> = BTreeSet::new();
         let mut pending_tasks: BTreeMap<Stage, BTreeSet<Box<dyn TaskBase>>> = BTreeMap::new();
-        let mut last_fetch_failure_time = 0;
+        let mut fetch_failure_duration = Duration::new(0, 0);
 
         //TODO update cache
         //TODO logging
@@ -369,8 +368,7 @@ impl DistributedScheduler {
 
         while num_finished != num_output_parts {
             let event_option = self.wait_for_event(run_id, self.poll_timeout);
-            let time = SystemTime::now();
-            let time = time.duration_since(UNIX_EPOCH).unwrap().as_millis();
+            let start_time = Instant::now();
 
             if let Some(mut evt) = event_option {
                 info!("event starting");
@@ -566,14 +564,14 @@ impl DistributedScheduler {
                                 .unwrap()
                                 .clone(),
                         );
-                        last_fetch_failure_time = time;
+                        fetch_failure_duration = start_time.elapsed();
                     }
                     _ => {
                         //TODO error handling
                     }
                 }
             }
-            if !failed.is_empty() && (time > (last_fetch_failure_time + self.resubmit_timeout)) {
+            if !failed.is_empty() && fetch_failure_duration.as_millis() > self.resubmit_timeout {
                 self.update_cache_locs();
                 for stage in &failed {
                     self.submit_stage(
@@ -769,17 +767,14 @@ impl DistributedScheduler {
         Vec::new()
     }
 
-    fn wait_for_event(&mut self, run_id: usize, timeout: i64) -> Option<CompletionEvent> {
-        let timer = SystemTime::now();
-        let end_time = timer.elapsed().unwrap().as_millis() + timeout as u128;
+    fn wait_for_event(&mut self, run_id: usize, timeout: u64) -> Option<CompletionEvent> {
+        let end = Instant::now() + Duration::from_millis(timeout);
         while self.event_queues.lock().get(&run_id).unwrap().is_empty() {
-            let time = timer.elapsed().unwrap().as_millis();
-            if time >= end_time {
+            if Instant::now() > end {
                 return None;
-            } else {
-                let dur = time::Duration::from_millis((end_time - time) as u64);
-                thread::sleep(dur);
             }
+
+            thread::sleep(Duration::from_millis(250));
         }
         self.event_queues
             .lock()

--- a/src/distributed_scheduler.rs
+++ b/src/distributed_scheduler.rs
@@ -49,8 +49,8 @@ pub struct DistributedScheduler {
     taskid_to_slaveid: HashMap<String, String>,
     job_tasks: HashMap<usize, HashSet<String>>,
     slaves_with_executors: HashSet<String>,
-    server_uris: Arc<Mutex<VecDeque<(String, usize)>>>,
-    port: usize,
+    server_uris: Arc<Mutex<VecDeque<(String, u16)>>>,
+    port: u16,
     map_output_tracker: MapOutputTracker,
 }
 
@@ -59,8 +59,8 @@ impl DistributedScheduler {
         threads: usize,
         max_failures: usize,
         master: bool,
-        servers: Option<Vec<(String, usize)>>,
-        port: usize,
+        servers: Option<Vec<(String, u16)>>,
+        port: u16,
         //        map_output_tracker: MapOutputTracker,
     ) -> Self {
         //        unimplemented!()

--- a/src/distributed_scheduler.rs
+++ b/src/distributed_scheduler.rs
@@ -171,14 +171,14 @@ impl DistributedScheduler {
         env::env
             .cache_tracker
             .register_rdd(rdd_base.get_rdd_id(), rdd_base.number_of_splits());
-        if !shuffle_dependency.is_none() {
+        if let Some(shuffle_dependency) = shuffle_dependency.clone() {
             info!("shuffle dependcy and registering mapoutput tracker");
             self.map_output_tracker.register_shuffle(
-                shuffle_dependency.clone().unwrap().get_shuffle_id(),
+                shuffle_dependency.get_shuffle_id(),
                 rdd_base.number_of_splits(),
             );
             info!("new stage tracker after");
-        }
+        };
         let id = self.next_stage_id.fetch_add(1, Ordering::SeqCst);
         info!("new stage id {}", id);
         let stage = Stage::new(

--- a/src/env.rs
+++ b/src/env.rs
@@ -16,20 +16,6 @@ pub struct Env {
     pub cache_tracker: CacheTracker,
 }
 
-#[derive(Deserialize)]
-struct Hosts {
-    master: SocketAddr,
-    //slaves: Vec<SocketAddr>,
-}
-
-impl Hosts {
-    fn load_from<R: Read>(mut reader: R) -> std::io::Result<Self> {
-        let mut data = String::new();
-        reader.read_to_string(&mut data)?;
-        Ok(toml::from_str(&data).expect("unable to process the hosts.conf file"))
-    }
-}
-
 impl Env {
     pub fn new(master_addr: SocketAddr) -> Self {
         Env {
@@ -52,17 +38,8 @@ lazy_static! {
         }
     };
     pub static ref the_cache: BoundedMemoryCache = { BoundedMemoryCache::new() };
-    pub static ref env: Env = {
-        let host_path = std::env::home_dir().unwrap().join("hosts.conf");
-        let host_path_string = host_path.to_string_lossy();
-        let mut host_file = File::open(&host_path).unwrap_or_else(|_| panic!("Unable to open the file: {}", host_path_string));
-        let mut hosts = String::new();
-        host_file
-            .read_to_string(&mut hosts)
-            .unwrap_or_else(|_| panic!("Unable to read the file: {}", host_path_string));
-        let hosts: Hosts = toml::from_str(&hosts).unwrap_or_else(|_| panic!("Unable to process the {} file in env", host_path_string));
-        Env::new(hosts.master)
-    };
+    pub static ref hosts: Hosts = Hosts::load().unwrap();
+    pub static ref env: Env = Env::new(hosts.master);
 
     pub static ref local_ip: Ipv4Addr = std::env::var("SPARK_LOCAL_IP")
         .expect("You must set the SPARK_LOCAL_IP environment variable")

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,4 +35,7 @@ pub enum Error {
         source: toml::de::Error,
         path: PathBuf,
     },
+
+    #[error("failed to parse slave address {0}")]
+    ParseSlaveAddress(String),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 use std::path::PathBuf;
 use thiserror::Error;
 
@@ -25,6 +26,9 @@ pub enum Error {
 
     #[error("failed to determine the home directory")]
     NoHome,
+
+    #[error("failed to convert {:?} to a String", .0)]
+    OsStringToString(OsString),
 
     #[error("failed to parse hosts file at {}", path.display())]
     ParseHosts {

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,11 +12,14 @@ pub enum Error {
         command: String,
     },
 
-    #[error("failed to create the log file")]
-    CreateLogFile(#[source] std::io::Error),
+    #[error("couldn't determine the current binary's name")]
+    CurrentBinaryName,
 
     #[error("couldn't determine the path to the current binary")]
     CurrentBinaryPath,
+
+    #[error("failed to create the log file")]
+    CreateLogFile(#[source] std::io::Error),
 
     #[error("failed to create the terminal logger")]
     CreateTerminalLogger,
@@ -41,6 +44,9 @@ pub enum Error {
         source: toml::de::Error,
         path: PathBuf,
     },
+
+    #[error("failed to convetr {} to a String", .0.display())]
+    PathToString(PathBuf),
 
     #[error("failed to parse slave address {0}")]
     ParseSlaveAddress(String),

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,12 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("failed to run {command}")]
+    CommandOutput {
+        source: std::io::Error,
+        command: String,
+    },
+
     #[error("failed to create the log file")]
     CreateLogFile(#[source] std::io::Error),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("couldn't determine the path to the current binary")]
+    CurrentBinaryPath,
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,9 @@ pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("failed to create the log file")]
+    CreateLogFile(#[source] std::io::Error),
+
     #[error("couldn't determine the path to the current binary")]
     CurrentBinaryPath,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, Error>;
@@ -9,4 +10,22 @@ pub enum Error {
 
     #[error("couldn't determine the path to the current binary")]
     CurrentBinaryPath,
+
+    #[error("failed to parse the executor port")]
+    ExecutorPort(#[source] std::num::ParseIntError),
+
+    #[error("failed to load hosts file from {}", path.display())]
+    LoadHosts {
+        source: std::io::Error,
+        path: PathBuf,
+    },
+
+    #[error("failed to determine the home directory")]
+    NoHome,
+
+    #[error("failed to parse hosts file at {}", path.display())]
+    ParseHosts {
+        source: toml::de::Error,
+        path: PathBuf,
+    },
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,9 @@ pub enum Error {
     #[error("couldn't determine the path to the current binary")]
     CurrentBinaryPath,
 
+    #[error("failed to create the terminal logger")]
+    CreateTerminalLogger,
+
     #[error("failed to parse the executor port")]
     ExecutorPort(#[source] std::num::ParseIntError),
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -7,12 +7,12 @@ use std::time::SystemTime;
 use threadpool::ThreadPool;
 
 pub struct Executor {
-    port: usize,
+    port: u16,
     //    thread_pool: ThreadPool,
 }
 
 impl Executor {
-    pub fn new(port: usize) -> Self {
+    pub fn new(port: u16) -> Self {
         Executor {
             port,
             //            thread_pool: ThreadPool::new(1),

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -3,7 +3,7 @@ use capnp::serialize_packed;
 use std::net::TcpListener;
 //use std::net::TcpStream;
 use std::thread;
-use std::time::SystemTime;
+use std::time::Instant;
 use threadpool::ThreadPool;
 
 pub struct Executor {
@@ -63,7 +63,7 @@ impl Executor {
                                 server_port,
                                 task_data.get_msg().unwrap().len()
                             );
-                            let now = SystemTime::now();
+                            let start = Instant::now();
                             //                            let local_dir_root = "/tmp";
                             //                            let uuid = Uuid::new_v4();
                             //                            let local_dir_uuid = uuid.to_string();
@@ -108,9 +108,9 @@ impl Executor {
                             info!(
                                 "time taken in server for deserializing:{} {}",
                                 server_port,
-                                now.elapsed().unwrap().as_millis(),
+                                start.elapsed().as_millis(),
                             );
-                            let now = SystemTime::now();
+                            let start = Instant::now();
                             info!("executing the trait from server port {}", server_port);
                             //TODO change attempt id from 0 to proper value
                             let result = des_task.run(0);
@@ -118,9 +118,9 @@ impl Executor {
                             info!(
                                 "time taken in server for running:{} {}",
                                 server_port,
-                                now.elapsed().unwrap().as_millis(),
+                                start.elapsed().as_millis(),
                             );
-                            let now = SystemTime::now();
+                            let start = Instant::now();
                             let result = bincode::serialize(&result).unwrap();
                             info!(
                                 "task in executor {} {} slave result len",
@@ -130,7 +130,7 @@ impl Executor {
                             info!(
                                 "time taken in server for serializing:{} {}",
                                 server_port,
-                                now.elapsed().unwrap().as_millis(),
+                                start.elapsed().as_millis(),
                             );
                             let mut message = ::capnp::message::Builder::new_default();
                             let mut task_data = message.init_root::<serialized_data::Builder>();

--- a/src/hosts.rs
+++ b/src/hosts.rs
@@ -1,0 +1,54 @@
+use super::*;
+use std::net::SocketAddr;
+use std::path::Path;
+
+/// Handles loading of the hosts configuration.
+#[derive(Debug, Deserialize)]
+pub struct Hosts {
+    pub master: SocketAddr,
+    /// The slaves have the format "user@address", e.g. "worker@192.168.0.2"
+    pub slaves: Vec<String>,
+}
+
+impl Hosts {
+    pub fn load() -> Result<Self> {
+        let home = std::env::home_dir().ok_or(Error::NoHome)?;
+        Hosts::load_from(home.join("hosts.conf"))
+    }
+
+    fn load_from<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let s = std::fs::read_to_string(&path).map_err(|e| Error::LoadHosts {
+            source: e,
+            path: path.as_ref().into(),
+        })?;
+
+        toml::from_str(&s).map_err(|e| Error::ParseHosts {
+            source: e,
+            path: path.as_ref().into(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_missing_hosts_file() {
+        match Hosts::load_from("/does_not_exist").unwrap_err() {
+            Error::LoadHosts { source: _, path: _ } => {}
+            _ => panic!("Expected Error::LoadHosts"),
+        }
+    }
+
+    #[test]
+    fn test_invalid_hosts_file() {
+        let (mut file, path) = tempfile::NamedTempFile::new().unwrap().keep().unwrap();
+        file.write_all("invalid data".as_ref()).unwrap();
+
+        match Hosts::load_from(&path).unwrap_err() {
+            Error::ParseHosts { source: _, path: _ } => {}
+            _ => panic!("Expected Error::ParseHosts"),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ extern crate serde_closure;
 #[macro_use]
 extern crate lazy_static;
 extern crate capnp;
-use log::info;
+use log::{error, info};
 use std::io::prelude::*;
 pub mod serialized_data_capnp {
     include!(concat!(env!("OUT_DIR"), "/capnp/serialized_data_capnp.rs"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,3 +110,6 @@ use serializable_traits::{AnyData, Data, Func, SerFunc};
 
 mod env;
 //use env::*;
+
+pub mod error;
+pub use error::{Error, Result};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,3 +113,6 @@ mod env;
 
 pub mod error;
 pub use error::{Error, Result};
+
+mod hosts;
+use hosts::Hosts;

--- a/src/local_scheduler.rs
+++ b/src/local_scheduler.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread;
 use std::time;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
 use threadpool::ThreadPool;
 
 #[derive(Clone, Default)]
@@ -21,7 +21,7 @@ pub struct LocalScheduler {
     max_failures: usize,
     attempt_id: Arc<AtomicUsize>,
     resubmit_timeout: u128,
-    poll_timeout: i64,
+    poll_timeout: u64,
     event_queues: Arc<Mutex<HashMap<usize, VecDeque<CompletionEvent>>>>,
     next_job_id: Arc<AtomicUsize>,
     next_run_id: Arc<AtomicUsize>,
@@ -307,7 +307,7 @@ impl LocalScheduler {
         let mut running: BTreeSet<Stage> = BTreeSet::new();
         let mut failed: BTreeSet<Stage> = BTreeSet::new();
         let mut pending_tasks: BTreeMap<Stage, BTreeSet<Box<dyn TaskBase>>> = BTreeMap::new();
-        let mut last_fetch_failure_time = 0;
+        let mut fetch_failure_duration = Duration::new(0, 0);
 
         //TODO update cache
         //TODO logging
@@ -344,8 +344,7 @@ impl LocalScheduler {
 
         while num_finished != num_output_parts {
             let event_option = self.wait_for_event(run_id, self.poll_timeout);
-            let time = SystemTime::now();
-            let time = time.duration_since(UNIX_EPOCH).unwrap().as_millis();
+            let start = Instant::now();
 
             if let Some(mut evt) = event_option {
                 info!("event starting");
@@ -548,14 +547,14 @@ impl LocalScheduler {
                                 .unwrap()
                                 .clone(),
                         );
-                        last_fetch_failure_time = time;
+                        fetch_failure_duration = start.elapsed()
                     }
                     _ => {
                         //TODO error handling
                     }
                 }
             }
-            if !failed.is_empty() && (time > (last_fetch_failure_time + self.resubmit_timeout)) {
+            if !failed.is_empty() && fetch_failure_duration.as_millis() > self.resubmit_timeout {
                 self.update_cache_locs();
                 for stage in &failed {
                     self.submit_stage(
@@ -752,18 +751,14 @@ impl LocalScheduler {
         Vec::new()
     }
 
-    fn wait_for_event(&mut self, run_id: usize, timeout: i64) -> Option<CompletionEvent> {
-        let timer = SystemTime::now();
-        let end_time = timer.elapsed().unwrap().as_millis() + timeout as u128;
-        //        println!("inside wait for event with run_id - {}", run_id);
+    fn wait_for_event(&mut self, run_id: usize, timeout: u64) -> Option<CompletionEvent> {
+        let end = Instant::now() + Duration::from_millis(timeout);
         while self.event_queues.lock().get(&run_id).unwrap().is_empty() {
-            let time = timer.elapsed().unwrap().as_millis();
-            if time >= end_time {
+            if Instant::now() > end {
                 return None;
-            } else {
-                let dur = time::Duration::from_millis((end_time - time) as u64);
-                thread::sleep(dur);
             }
+
+            thread::sleep(Duration::from_millis(250));
         }
         self.event_queues
             .lock()

--- a/src/rdd.rs
+++ b/src/rdd.rs
@@ -246,7 +246,7 @@ pub trait Rdd<T: Data>: RddBase + Send + Sync + Serialize + Deserialize {
     }
 
     /// Return the first element in this RDD.
-    fn first(&self) -> Result<T, Box<dyn std::error::Error>>
+    fn first(&self) -> std::result::Result<T, Box<dyn std::error::Error>>
     where
         Self: Sized + 'static,
     {

--- a/src/shuffle_fetcher.rs
+++ b/src/shuffle_fetcher.rs
@@ -72,7 +72,8 @@ impl ShuffleFetcher {
                         fn f(
                             producer: Sender<(Vec<u8>, String)>,
                             url: String,
-                        ) -> Result<(), Box<dyn Error>> {
+                        ) -> std::result::Result<(), Box<dyn std::error::Error>>
+                        {
                             let mut res = reqwest::get(&url)?;
                             let len = &res.content_length();
                             let mut body = vec![0; len.unwrap() as usize];

--- a/src/shuffled_rdd.rs
+++ b/src/shuffled_rdd.rs
@@ -4,9 +4,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 //use std::marker::PhantomData;
 use std::sync::Arc;
-//use std::time;
-//use std::time::Duration;
-use std::time::SystemTime;
+use std::time::Instant;
 //use std::any::Any;
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -167,7 +165,7 @@ where
         };
 
         //TODO call fetch function after ShuffleFetcher is implemented
-        let time = SystemTime::now();
+        let start = Instant::now();
         let fetcher = ShuffleFetcher;
         fetcher.fetch(
             self.vals.context.clone(),
@@ -175,10 +173,7 @@ where
             split.get_index(),
             merge_pair,
         );
-        let dur = time.elapsed().unwrap().as_millis();
-        info!("time taken for fetching {}", dur);
-        let dur = time.elapsed().unwrap().as_millis();
-        info!("time taken for converting to hashset {}", dur);
+        info!("time taken for fetching {}", start.elapsed().as_millis());
         Box::new(combiners.into_iter().map(|(k, v)| (k, v.unwrap())))
 
         //        let res = res.collect::<Vec<_>>();

--- a/tests/test_pair_rdd.rs
+++ b/tests/test_pair_rdd.rs
@@ -3,7 +3,7 @@ extern crate serde_closure;
 
 #[test]
 fn test_group_by() {
-    let sc = Context::new("local");
+    let sc = Context::new("local").unwrap();
     let vec = vec![
         ("x".to_string(), 1),
         ("x".to_string(), 2),
@@ -37,7 +37,7 @@ fn test_group_by() {
 
 #[test]
 fn test_join() {
-    let sc = Context::new("local");
+    let sc = Context::new("local").unwrap();
     let col1 = vec![
         (1, ("A".to_string(), "B".to_string())),
         (2, ("C".to_string(), "D".to_string())),

--- a/tests/test_rdd.rs
+++ b/tests/test_rdd.rs
@@ -5,7 +5,7 @@ extern crate serde_closure;
 #[test]
 fn test_make_rdd() {
     // for distributed mode, use Context::new("distributed")
-    let sc = Context::new("local");
+    let sc = Context::new("local").unwrap();
     let col = sc.make_rdd((0..10).collect::<Vec<_>>(), 32);
     //Fn! will make the closures serializable. It is necessary. use serde_closure version 0.1.3.
     let vec_iter = col.map(Fn!(|i| (0..i).collect::<Vec<_>>()));
@@ -21,7 +21,7 @@ fn test_make_rdd() {
 
 #[test]
 fn test_take() {
-    let sc = Context::new("local");
+    let sc = Context::new("local").unwrap();
     let col1 = vec![1, 2, 3, 4, 5, 6];
     let col1_rdd = sc.parallelize(col1, 4);
 
@@ -42,7 +42,7 @@ fn test_take() {
 
 #[test]
 fn test_first() {
-    let sc = Context::new("local");
+    let sc = Context::new("local").unwrap();
     let col1 = vec![1, 2, 3, 4];
     let col1_rdd = sc.parallelize(col1, 4);
 
@@ -59,7 +59,7 @@ fn test_first() {
 #[test]
 fn test_distinct() {
     use std::collections::HashSet;
-    let sc = Context::new("local");
+    let sc = Context::new("local").unwrap();
     let rdd = sc.parallelize(vec![1, 2, 2, 2, 3, 3, 3, 4, 4, 5], 3);
     assert!(rdd.distinct().collect().len() == 5);
     assert!(


### PR DESCRIPTION
A few of us discussed which error handling crate to use on gitter.im and decided upon [thiserror](https://github.com/dtolnay/thiserror). This is because it conforms to `std::error:Error` - if it's desirable to change to another crate in the future it should be painless for us and seamless for people using native_spark.

This is a major API break for `Context::new` and also converts a couple of signed integers to unsigned to prevent propagation of invalid values (all values of u16 are valid ports, timeouts can't be negative, etc.).

I stopped at this point because I have to learn more about capnp, serde_closure, etc. in order to work out whether it's correct to return `Result`s for RPCs, or whether another approach is more appropriate.