### PR TITLE
Refactor local and distributed scheduler

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -58,7 +58,9 @@ impl Schedulers {
     {
         use Schedulers::*;
         match self {
-            Distributed(local) => local.run_job(func, final_rdd, partitions, allow_local),
+            Distributed(distributed) => {
+                distributed.run_job(func, final_rdd, partitions, allow_local)
+            }
             Local(local) => local.run_job(func, final_rdd, partitions, allow_local),
         }
     }

--- a/src/distributed_scheduler.rs
+++ b/src/distributed_scheduler.rs
@@ -1,19 +1,14 @@
 use super::*;
+use crate::scheduler::Scheduler;
 
 use capnp::serialize_packed;
-//use chrono::{DateTime, Utc};
-//use downcast_rs::Downcast;
 use parking_lot::Mutex;
 use std::any::Any;
 use std::collections::btree_map::BTreeMap;
 use std::collections::btree_set::BTreeSet;
 use std::collections::vec_deque::VecDeque;
 use std::collections::{HashMap, HashSet};
-//use std::intrinsics;
-//use std::io::prelude::*;
-//use std::io::BufReader;
 use std::iter::FromIterator;
-//use std::net::TcpListener;
 use std::net::{Ipv4Addr, TcpStream};
 use std::option::Option;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -21,6 +16,7 @@ use std::sync::Arc;
 use std::thread;
 use std::time;
 use std::time::{Duration, Instant};
+
 use threadpool::ThreadPool;
 
 //just for now, creating an entire scheduler functions without dag scheduler trait. Later change it to extend from dag scheduler
@@ -60,9 +56,7 @@ impl DistributedScheduler {
         master: bool,
         servers: Option<Vec<(String, u16)>>,
         port: u16,
-        //        map_output_tracker: MapOutputTracker,
     ) -> Self {
-        //        unimplemented!()
         info!(
             "starting distributed scheduler in client - {} {}",
             master, port
@@ -105,21 +99,6 @@ impl DistributedScheduler {
         }
     }
 
-    fn get_cache_locs(&self, rdd: Arc<dyn RddBase>) -> Option<Vec<Vec<Ipv4Addr>>> {
-        let cache_locs = self.cache_locs.lock();
-        let locs_opt = cache_locs.get(&rdd.get_rdd_id());
-        match locs_opt {
-            Some(locs) => Some(locs.clone()),
-            None => None,
-        }
-        //        (self.cache_locs.lock().get(&rdd.get_rdd_id())).clone()
-    }
-
-    fn update_cache_locs(&self) {
-        let mut locs = self.cache_locs.lock();
-        *locs = env::env.cache_tracker.get_location_snapshot();
-    }
-
     fn task_ended(
         event_queues: Arc<Mutex<HashMap<usize, VecDeque<CompletionEvent>>>>,
         task: Box<dyn TaskBase>,
@@ -141,170 +120,7 @@ impl DistributedScheduler {
         }
     }
 
-    fn get_shuffle_map_stage(&self, shuf: Arc<dyn ShuffleDependencyTrait>) -> Stage {
-        info!("inside get_shufflemap stage");
-        let stage = match self.shuffle_to_map_stage.lock().get(&shuf.get_shuffle_id()) {
-            Some(s) => Some(s.clone()),
-            None => None,
-        };
-        match stage {
-            Some(stage) => stage.clone(),
-            None => {
-                info!("inside get_shufflemap stage before");
-                let stage = self.new_stage(shuf.get_rdd_base(), Some(shuf.clone()));
-                self.shuffle_to_map_stage
-                    .lock()
-                    .insert(shuf.get_shuffle_id(), stage.clone());
-                info!("inside get_shufflemap return");
-                stage
-            }
-        }
-    }
-
-    fn new_stage(
-        &self,
-        rdd_base: Arc<dyn RddBase>,
-        shuffle_dependency: Option<Arc<dyn ShuffleDependencyTrait>>,
-    ) -> Stage {
-        info!("inside new stage");
-        env::env
-            .cache_tracker
-            .register_rdd(rdd_base.get_rdd_id(), rdd_base.number_of_splits());
-        if let Some(shuffle_dependency) = shuffle_dependency.clone() {
-            info!("shuffle dependcy and registering mapoutput tracker");
-            self.map_output_tracker.register_shuffle(
-                shuffle_dependency.get_shuffle_id(),
-                rdd_base.number_of_splits(),
-            );
-            info!("new stage tracker after");
-        };
-        let id = self.next_stage_id.fetch_add(1, Ordering::SeqCst);
-        info!("new stage id {}", id);
-        let stage = Stage::new(
-            id,
-            rdd_base.clone(),
-            shuffle_dependency,
-            self.get_parent_stages(rdd_base),
-        );
-        self.id_to_stage.lock().insert(id, stage.clone());
-        info!("new stage stage return");
-        stage
-    }
-
-    fn visit_for_parent_stages(
-        &self,
-        parents: &mut BTreeSet<Stage>,
-        visited: &mut BTreeSet<Arc<dyn RddBase>>,
-        rdd: Arc<dyn RddBase>,
-    ) {
-        info!(
-            "parent stages {:?}",
-            parents.iter().map(|x| x.id).collect::<Vec<_>>()
-        );
-        info!(
-            "visisted stages {:?}",
-            visited.iter().map(|x| x.get_rdd_id()).collect::<Vec<_>>()
-        );
-        if !visited.contains(&rdd) {
-            visited.insert(rdd.clone());
-            env::env
-                .cache_tracker
-                .register_rdd(rdd.get_rdd_id(), rdd.number_of_splits());
-            for dep in rdd.get_dependencies() {
-                match dep {
-                    Dependency::ShuffleDependency(shuf_dep) => {
-                        parents.insert(self.get_shuffle_map_stage(shuf_dep.clone()));
-                    }
-                    Dependency::OneToOneDependency(oto_dep) => {
-                        self.visit_for_parent_stages(parents, visited, oto_dep.get_rdd_base())
-                    }
-                    Dependency::NarrowDependency(nar_dep) => {
-                        self.visit_for_parent_stages(parents, visited, nar_dep.get_rdd_base())
-                    } //TODO finish range dependency
-                }
-            }
-        }
-    }
-
-    fn get_parent_stages(&self, rdd: Arc<dyn RddBase>) -> Vec<Stage> {
-        info!("inside get parent stages");
-        let mut parents: BTreeSet<Stage> = BTreeSet::new();
-        let mut visited: BTreeSet<Arc<dyn RddBase>> = BTreeSet::new();
-        self.visit_for_parent_stages(&mut parents, &mut visited, rdd.clone());
-        info!(
-            "parent stages {:?}",
-            parents.iter().map(|x| x.id).collect::<Vec<_>>()
-        );
-        parents.into_iter().collect()
-    }
-
-    fn visit_for_missing_parent_stages(
-        &self,
-        missing: &mut BTreeSet<Stage>,
-        visited: &mut BTreeSet<Arc<dyn RddBase>>,
-        rdd: Arc<dyn RddBase>,
-    ) {
-        info!(
-            "missing stages {:?}",
-            missing.iter().map(|x| x.id).collect::<Vec<_>>()
-        );
-        info!(
-            "visisted stages {:?}",
-            visited.iter().map(|x| x.get_rdd_id()).collect::<Vec<_>>()
-        );
-        if !visited.contains(&rdd) {
-            visited.insert(rdd.clone());
-            // TODO CacheTracker register
-            for p in 0..rdd.number_of_splits() {
-                let locs = self.get_cache_locs(rdd.clone());
-                info!("cache locs {:?}", locs);
-                if locs == None {
-                    for dep in rdd.get_dependencies() {
-                        info!("for dep in missing stages ");
-                        match dep {
-                            Dependency::ShuffleDependency(shuf_dep) => {
-                                let stage = self.get_shuffle_map_stage(shuf_dep.clone());
-                                info!("shuffle stage in missing stages {:?}", stage.id);
-                                if !stage.is_available() {
-                                    info!(
-                                        "inserting shuffle stage in missing stages {:?}",
-                                        stage.id
-                                    );
-                                    missing.insert(stage);
-                                }
-                            }
-                            Dependency::NarrowDependency(nar_dep) => {
-                                info!("narrow stage in missing stages ");
-                                self.visit_for_missing_parent_stages(
-                                    missing,
-                                    visited,
-                                    nar_dep.get_rdd_base(),
-                                )
-                            }
-                            Dependency::OneToOneDependency(one_dep) => {
-                                info!("one to one stage in missing stages ");
-                                self.visit_for_missing_parent_stages(
-                                    missing,
-                                    visited,
-                                    one_dep.get_rdd_base(),
-                                )
-                            } //TODO finish range dependency
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    fn get_missing_parent_stages(&self, stage: Stage) -> Vec<Stage> {
-        info!("inside get missing parent stages");
-        let mut missing: BTreeSet<Stage> = BTreeSet::new();
-        let mut visited: BTreeSet<Arc<dyn RddBase>> = BTreeSet::new();
-        self.visit_for_missing_parent_stages(&mut missing, &mut visited, stage.get_rdd());
-        missing.into_iter().collect()
-    }
-
-    pub fn run_job<T: Data, U: Data, F>(
+    pub fn run_job<T: Data, U: Data, F, RT>(
         &self,
         func: Arc<F>,
         final_rdd: Arc<dyn Rdd<Item = T>>,
@@ -318,55 +134,35 @@ impl DistributedScheduler {
             "shuffle maanger in final rdd of run job {:?}",
             env::env.shuffle_manager
         );
-        let thread_pool = Arc::new(ThreadPool::new(self.threads));
-        let run_id = self.next_run_id.fetch_add(1, Ordering::SeqCst);
-        let output_parts = partitions;
-        let num_output_parts = output_parts.len();
-        let final_stage = self.new_stage(final_rdd.get_rdd_base(), None);
-        let mut results: Vec<Option<U>> = (0..num_output_parts).map(|_| None).collect();
-        let mut finished: Vec<bool> = (0..num_output_parts).map(|_| false).collect();
+
+        let mut jt = JobTracker::from_scheduler(self, func.clone(), final_rdd.clone(), partitions);
+        let mut results: Vec<Option<U>> = (0..jt.num_output_parts).map(|_| None).collect();
         let mut num_finished = 0;
-        let mut waiting: BTreeSet<Stage> = BTreeSet::new();
-        let mut running: BTreeSet<Stage> = BTreeSet::new();
-        let mut failed: BTreeSet<Stage> = BTreeSet::new();
-        let mut pending_tasks: BTreeMap<Stage, BTreeSet<Box<dyn TaskBase>>> = BTreeMap::new();
         let mut fetch_failure_duration = Duration::new(0, 0);
 
         //TODO update cache
         //TODO logging
 
-        if allow_local && final_stage.parents.is_empty() && (num_output_parts == 1) {
-            let split = (final_rdd.splits()[output_parts[0]]).clone();
-            let task_context = TasKContext::new(final_stage.id, output_parts[0], 0);
-            return Ok(vec![func((task_context, final_rdd.iterator(split)?))]);
+        if allow_local {
+            if let Some(result) = LocalScheduler::local_execution(jt.clone())? {
+                return Ok(result);
+            }
         }
 
-        self.event_queues.lock().insert(run_id, VecDeque::new());
+        self.event_queues.lock().insert(jt.run_id, VecDeque::new());
 
-        self.submit_stage(
-            final_stage.clone(),
-            &mut waiting,
-            &mut running,
-            &mut finished,
-            &mut pending_tasks,
-            output_parts.clone(),
-            num_output_parts,
-            final_stage.clone(),
-            func.clone(),
-            final_rdd.clone(),
-            run_id,
-            thread_pool.clone(),
-        );
+        self.submit_stage(jt.final_stage.clone(), jt.clone());
         info!(
             "pending stages and tasks {:?}",
-            pending_tasks
+            jt.pending_tasks
+                .borrow()
                 .iter()
                 .map(|(k, v)| (k.id, v.iter().map(|x| x.get_task_id()).collect::<Vec<_>>()))
                 .collect::<Vec<_>>()
         );
 
-        while num_finished != num_output_parts {
-            let event_option = self.wait_for_event(run_id, self.poll_timeout);
+        while num_finished != jt.num_output_parts {
+            let event_option = self.wait_for_event(jt.run_id, self.poll_timeout);
             let start_time = Instant::now();
 
             if let Some(mut evt) = event_option {
@@ -377,189 +173,18 @@ impl DistributedScheduler {
                     stage.id,
                     evt.task.get_task_id()
                 );
-                pending_tasks.get_mut(&stage).unwrap().remove(&evt.task);
+                jt.pending_tasks
+                    .borrow_mut()
+                    .get_mut(&stage)
+                    .unwrap()
+                    .remove(&evt.task);
                 use super::dag_scheduler::TastEndReason::*;
                 match evt.reason {
                     Success => {
-                        //TODO logging
-                        //TODO add to Accumulator
-
-                        // ResultTask alone done now.
-                        //                        if let Some(result) = evt.get_result::<U>();
-                        let result_type =
-                            evt.task.downcast_ref::<ResultTask<T, U, F>>().is_some();
-                        //                        println!("result task in master {} {:?}", self.master, result_type);
-                        if result_type {
-                            if let Ok(rt) = evt.task.downcast::<ResultTask<T, U, F>>() {
-                                //                                println!(
-                                //                                    "result task result before unwrapping in master {}",
-                                //                                    self.master
-                                //                                );
-                                let result = evt
-                                    .result
-                                    .take()
-                                    .unwrap()
-                                    .downcast_ref::<U>()
-                                    .unwrap()
-                                    .clone();
-                                results[rt.output_id] = Some(result);
-                                finished[rt.output_id] = true;
-                                num_finished += 1;
-                            }
-                        } else if let Ok(smt) = evt.task.downcast::<ShuffleMapTask>() {
-                            let result = evt
-                                .result
-                                .take()
-                                .unwrap()
-                                .downcast_ref::<String>()
-                                .unwrap()
-                                .clone();
-                            //                                let result = *result;
-                            //                                let result: serde_traitobject::Box<serde_traitobject::Any> =
-                            //                                    evt.result.take().unwrap();
-                            //                                //                                let result = result.into_any();
-                            //                                let result: Box<String> =
-                            //                                    Box::<Any>::downcast(result.into_any()).unwrap();
-                            //                                //                                let result = result.downcast::<String>().unwrap();
-                            //                                let result = *result;
-                            //                                info!("result inside queue {:?}", result);
-                            self.id_to_stage
-                                .lock()
-                                .get_mut(&smt.stage_id)
-                                .unwrap()
-                                .add_output_loc(smt.partition, result);
-                            let stage = self.id_to_stage.lock().clone()[&smt.stage_id].clone();
-                            info!(
-                                "pending stages {:?}",
-                                pending_tasks
-                                    .iter()
-                                    .map(|(x, y)| (
-                                        x.id,
-                                        y.iter().map(|k| k.get_task_id()).collect::<Vec<_>>()
-                                    ))
-                                    .collect::<Vec<_>>()
-                            );
-                            info!(
-                                "pending tasks {:?}",
-                                pending_tasks
-                                    .get(&stage)
-                                    .unwrap()
-                                    .iter()
-                                    .map(|x| x.get_task_id())
-                                    .collect::<Vec<_>>()
-                            );
-                            info!(
-                                "running {:?}",
-                                running.iter().map(|x| x.id).collect::<Vec<_>>()
-                            );
-                            info!(
-                                "waiting {:?}",
-                                waiting.iter().map(|x| x.id).collect::<Vec<_>>()
-                            );
-
-                            if running.contains(&stage)
-                                && pending_tasks.get(&stage).unwrap().is_empty()
-                            {
-                                info!("here before registering map outputs ");
-                                //TODO logging
-                                running.remove(&stage);
-                                if stage.shuffle_dependency.is_some() {
-                                    info!(
-                                        "stage output locs before register mapoutput tracker {:?}",
-                                        stage.output_locs
-                                    );
-                                    let locs = stage
-                                        .output_locs
-                                        .iter()
-                                        .map(|x| match x.get(0) {
-                                            Some(s) => Some(s.to_owned()),
-                                            None => None,
-                                        })
-                                        .collect();
-                                    info!(
-                                        "locs for shuffle id {:?} {:?}",
-                                        stage.clone().shuffle_dependency.unwrap().get_shuffle_id(),
-                                        locs
-                                    );
-                                    self.map_output_tracker.register_map_outputs(
-                                        stage.shuffle_dependency.unwrap().get_shuffle_id(),
-                                        locs,
-                                    );
-                                    info!("here after registering map outputs ");
-                                }
-                                //TODO Cache
-                                self.update_cache_locs();
-                                let mut newly_runnable = Vec::new();
-                                for stage in &waiting {
-                                    info!(
-                                        "waiting stage parent stages for stage {} are {:?}",
-                                        stage.id,
-                                        self.get_missing_parent_stages(stage.clone())
-                                            .iter()
-                                            .map(|x| x.id)
-                                            .collect::<Vec<_>>()
-                                    );
-                                    if self.get_missing_parent_stages(stage.clone()).is_empty() {
-                                        newly_runnable.push(stage.clone())
-                                    }
-                                }
-                                for stage in &newly_runnable {
-                                    waiting.remove(stage);
-                                }
-                                for stage in &newly_runnable {
-                                    running.insert(stage.clone());
-                                }
-                                for stage in newly_runnable {
-                                    self.submit_missing_tasks(
-                                        stage,
-                                        &mut finished,
-                                        &mut pending_tasks,
-                                        output_parts.clone(),
-                                        num_output_parts,
-                                        final_stage.clone(),
-                                        func.clone(),
-                                        final_rdd.clone(),
-                                        run_id,
-                                        thread_pool.clone(),
-                                    );
-                                }
-                            }
-                        }
+                        self.on_event_success(evt, &mut results, &mut num_finished, jt.clone())
                     }
-                    FetchFailed(FetchFailedVals {
-                        server_uri,
-                        shuffle_id,
-                        map_id,
-                        reduce_id,
-                    }) => {
-                        //TODO mapoutput tacker needs to be finished for this
-                        let failed_stage = self
-                            .id_to_stage
-                            .lock()
-                            .get(&evt.task.get_stage_id())
-                            .unwrap()
-                            .clone();
-                        running.remove(&failed_stage);
-                        failed.insert(failed_stage);
-                        //TODO logging
-                        self.shuffle_to_map_stage
-                            .lock()
-                            .get_mut(&shuffle_id)
-                            .unwrap()
-                            .remove_output_loc(map_id, server_uri.clone());
-                        self.map_output_tracker.unregister_map_output(
-                            shuffle_id,
-                            map_id,
-                            server_uri.clone(),
-                        );
-                        //logging
-                        failed.insert(
-                            self.shuffle_to_map_stage
-                                .lock()
-                                .get(&shuffle_id)
-                                .unwrap()
-                                .clone(),
-                        );
+                    FetchFailed(failed_vals) => {
+                        self.on_event_failure(jt.clone(), failed_vals, evt.task.get_stage_id());
                         fetch_failure_duration = start_time.elapsed();
                     }
                     _ => {
@@ -567,31 +192,19 @@ impl DistributedScheduler {
                     }
                 }
             }
-            if !failed.is_empty() && fetch_failure_duration.as_millis() > self.resubmit_timeout {
+
+            if !jt.failed.borrow().is_empty()
+                && fetch_failure_duration.as_millis() > self.resubmit_timeout
+            {
                 self.update_cache_locs();
-                for stage in &failed {
-                    self.submit_stage(
-                        stage.clone(),
-                        &mut waiting,
-                        &mut running,
-                        &mut finished,
-                        &mut pending_tasks,
-                        output_parts.clone(),
-                        num_output_parts,
-                        final_stage.clone(),
-                        func.clone(),
-                        final_rdd.clone(),
-                        run_id,
-                        thread_pool.clone(),
-                    );
+                for stage in jt.failed.borrow().iter() {
+                    self.submit_stage(stage.clone(), jt.clone());
                 }
-                failed.clear();
+                jt.failed.borrow_mut().clear();
             }
         }
 
-        self.event_queues.lock().remove(&run_id);
-        //        let dur = time::Duration::from_millis(20000);
-        //        thread::sleep(dur);
+        self.event_queues.lock().remove(&jt.run_id);
         Ok(results
             .into_iter()
             .map(|s| match s {
@@ -599,166 +212,6 @@ impl DistributedScheduler {
                 None => panic!("some results still missing"),
             })
             .collect())
-    }
-
-    fn submit_stage<T: Data, U: Data, F>(
-        &self,
-        stage: Stage,
-        waiting: &mut BTreeSet<Stage>,
-        running: &mut BTreeSet<Stage>,
-        finished: &mut Vec<bool>,
-        pending_tasks: &mut BTreeMap<Stage, BTreeSet<Box<dyn TaskBase>>>,
-        output_parts: Vec<usize>,
-        num_output_parts: usize,
-        final_stage: Stage,
-        func: Arc<F>,
-        final_rdd: Arc<dyn Rdd<Item = T>>,
-        run_id: usize,
-        thread_pool: Arc<ThreadPool>,
-    ) where
-        F: SerFunc((TasKContext, Box<dyn Iterator<Item = T>>)) -> U,
-    {
-        info!("submiting stage {}", stage.id);
-        if !waiting.contains(&stage) && !running.contains(&stage) {
-            let missing = self.get_missing_parent_stages(stage.clone());
-            info!(
-                "inside submit stage missing stages {:?}",
-                missing.iter().map(|x| x.id).collect::<Vec<_>>()
-            );
-            if missing.is_empty() {
-                self.submit_missing_tasks(
-                    stage.clone(),
-                    finished,
-                    pending_tasks,
-                    output_parts.clone(),
-                    num_output_parts,
-                    final_stage.clone(),
-                    func,
-                    final_rdd.clone(),
-                    run_id,
-                    thread_pool.clone(),
-                );
-                running.insert(stage.clone());
-            } else {
-                for parent in missing {
-                    self.submit_stage(
-                        parent,
-                        waiting,
-                        running,
-                        finished,
-                        pending_tasks,
-                        output_parts.clone(),
-                        num_output_parts,
-                        final_stage.clone(),
-                        func.clone(),
-                        final_rdd.clone(),
-                        run_id,
-                        thread_pool.clone(),
-                    );
-                }
-                waiting.insert(stage.clone());
-            }
-        }
-    }
-
-    fn submit_missing_tasks<T: Data, U: Data, F>(
-        &self,
-        stage: Stage,
-        finished: &mut Vec<bool>,
-        pending_tasks: &mut BTreeMap<Stage, BTreeSet<Box<dyn TaskBase>>>,
-        output_parts: Vec<usize>,
-        num_output_parts: usize,
-        final_stage: Stage,
-        func: Arc<F>,
-        final_rdd: Arc<dyn Rdd<Item = T>>,
-        run_id: usize,
-        thread_pool: Arc<ThreadPool>,
-    ) where
-        F: SerFunc((TasKContext, Box<dyn Iterator<Item = T>>)) -> U,
-    {
-        let my_pending = pending_tasks
-            .entry(stage.clone())
-            .or_insert_with(BTreeSet::new);
-
-        if stage == final_stage {
-            info!("final stage {}", stage.id);
-            let mut id_in_job = 0;
-            for (id, part) in output_parts.iter().enumerate().take(num_output_parts) {
-                let locs = self.get_preferred_locs(final_rdd.get_rdd_base(), *part);
-                let result_task = ResultTask::new(
-                    self.next_task_id.fetch_add(1, Ordering::SeqCst),
-                    run_id,
-                    final_stage.id,
-                    final_rdd.clone(),
-                    func.clone(),
-                    *part,
-                    locs,
-                    id,
-                );
-                my_pending.insert(Box::new(result_task.clone()));
-                self.submit_task::<T, U, F>(
-                    TaskOption::ResultTask(Box::new(result_task)),
-                    id_in_job,
-                    thread_pool.clone(),
-                );
-                id_in_job += 1;
-            }
-        } else {
-            let mut id_in_job = 0;
-            for p in 0..stage.num_partitions {
-                info!("shuffle_stage {}", stage.id);
-                if stage.output_locs[p].is_empty() {
-                    let locs = self.get_preferred_locs(stage.get_rdd(), p);
-                    info!("creating task for {} partition  {}", stage.id, p);
-                    let shuffle_map_task = ShuffleMapTask::new(
-                        self.next_task_id.fetch_add(1, Ordering::SeqCst),
-                        run_id,
-                        stage.id,
-                        stage.rdd.clone(),
-                        stage.shuffle_dependency.clone().unwrap(),
-                        p,
-                        locs,
-                    );
-                    info!(
-                        "creating task for {} partition  {} and shuffle id {}",
-                        stage.id,
-                        p,
-                        shuffle_map_task.dep.get_shuffle_id()
-                    );
-                    my_pending.insert(Box::new(shuffle_map_task.clone()));
-                    self.submit_task::<T, U, F>(
-                        TaskOption::ShuffleMapTask(Box::new(shuffle_map_task)),
-                        id_in_job,
-                        thread_pool.clone(),
-                    );
-                    id_in_job += 1;
-                }
-            }
-        }
-    }
-
-    fn get_preferred_locs(&self, rdd: Arc<dyn RddBase>, partition: usize) -> Vec<Ipv4Addr> {
-        //TODO have to implement this completely
-        if let Some(cached) = self.get_cache_locs(rdd.clone()) {
-            if let Some(cached) = cached.get(partition) {
-                return cached.clone();
-            }
-        }
-        let rdd_prefs = rdd.preferred_locations(rdd.splits()[partition].clone());
-        if !rdd_prefs.is_empty() {
-            return rdd_prefs;
-        }
-        for dep in rdd.get_dependencies().iter() {
-            if let Dependency::NarrowDependency(nar_dep) = dep {
-                for in_part in nar_dep.get_parents(partition) {
-                    let locs = self.get_preferred_locs(nar_dep.get_rdd_base(), in_part);
-                    if !locs.is_empty() {
-                        return locs;
-                    }
-                }
-            }
-        }
-        Vec::new()
     }
 
     fn wait_for_event(&self, run_id: usize, timeout: u64) -> Option<CompletionEvent> {
@@ -888,6 +341,71 @@ impl DistributedScheduler {
             })
         }
     }
-}
 
-//TODO Serialize and Deserialize
+    fn update_cache_locs(&self) {
+        let mut locs = self.cache_locs.lock();
+        *locs = env::env.cache_tracker.get_location_snapshot();
+    }
+
+    fn insert_into_stage_cache(&mut self, id: usize, stage: Stage) {
+        self.id_to_stage.lock().insert(id, stage.clone());
+    }
+
+    fn register_shuffle(&mut self, shuffle_id: usize, num_maps: usize) {
+        self.map_output_tracker
+            .register_shuffle(shuffle_id, num_maps);
+    }
+
+    fn get_cache_locs(&self, rdd: Arc<dyn RddBase>) -> Option<Vec<Vec<Ipv4Addr>>> {
+        let cache_locs = self.cache_locs.lock();
+        let locs_opt = cache_locs.get(&rdd.get_rdd_id());
+        match locs_opt {
+            Some(locs) => Some(locs.clone()),
+            None => None,
+        }
+    }
+
+    fn get_missing_parent_stages(&self, stage: Stage) -> Vec<Stage> {
+        info!("inside get missing parent stages");
+        let mut missing: BTreeSet<Stage> = BTreeSet::new();
+        let mut visited: BTreeSet<Arc<dyn RddBase>> = BTreeSet::new();
+        self.visit_for_missing_parent_stages(&mut missing, &mut visited, stage.get_rdd());
+        missing.into_iter().collect()
+    }
+
+    fn get_next_job_id(&self) -> usize {
+        self.next_job_id.fetch_add(1, Ordering::SeqCst)
+    }
+
+    fn get_next_stage_id(&self) -> usize {
+        self.next_stage_id.fetch_add(1, Ordering::SeqCst)
+    }
+
+    fn get_next_task_id(&self) -> usize {
+        self.next_task_id.fetch_add(1, Ordering::SeqCst)
+    }
+
+    fn get_shuffle_map_stage(&self, shuf: Arc<dyn ShuffleDependencyTrait>) -> Stage {
+        info!("inside get_shufflemap stage");
+        let stage = match self.shuffle_to_map_stage.lock().get(&shuf.get_shuffle_id()) {
+            Some(s) => Some(s.clone()),
+            None => None,
+        };
+        match stage {
+            Some(stage) => stage.clone(),
+            None => {
+                info!("inside get_shufflemap stage before");
+                let stage = self.new_stage(shuf.get_rdd_base(), Some(shuf.clone()));
+                self.shuffle_to_map_stage
+                    .lock()
+                    .insert(shuf.get_shuffle_id(), stage.clone());
+                info!("inside get_shufflemap return");
+                stage
+            }
+        }
+    }
+
+    fn num_threads(&self) -> usize {
+        self.threads
+    }
+}

--- a/src/job.rs
+++ b/src/job.rs
@@ -1,4 +1,23 @@
+use crate::*;
+
+use std::any::Any;
+use std::cell::RefCell;
+use std::clone::Clone;
 use std::cmp::Ordering;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+use std::marker::PhantomData;
+use std::net::Ipv4Addr;
+use std::option::Option;
+use std::rc::Rc;
+use std::sync::{
+    atomic::{AtomicUsize, Ordering as OrdAtomic},
+    Arc,
+};
+use std::thread;
+use std::time;
+use std::time::{Duration, Instant};
+
+use threadpool::ThreadPool;
 
 #[derive(Clone, Debug)]
 pub struct Job {
@@ -30,6 +49,115 @@ impl Eq for Job {}
 impl Ord for Job {
     fn cmp(&self, other: &Job) -> Ordering {
         other.job_id.cmp(&self.job_id)
+    }
+}
+
+type PendingTasks = BTreeMap<Stage, BTreeSet<Box<dyn TaskBase>>>;
+
+/// Contains all the necessary types to run and track a job progress
+pub(crate) struct JobTracker<F, RT, U: Data, T: Data>
+where
+    F: SerFunc((TasKContext, Box<dyn Iterator<Item = T>>)) -> U,
+    RT: Rdd<T> + 'static,
+{
+    pub output_parts: Vec<usize>,
+    pub num_output_parts: usize,
+    pub final_stage: Stage,
+    pub func: Arc<F>,
+    pub final_rdd: Arc<RT>,
+    pub run_id: usize,
+    pub thread_pool: Rc<ThreadPool>,
+    pub waiting: Rc<RefCell<BTreeSet<Stage>>>,
+    pub running: Rc<RefCell<BTreeSet<Stage>>>,
+    pub failed: Rc<RefCell<BTreeSet<Stage>>>,
+    pub finished: Rc<RefCell<Vec<bool>>>,
+    pub pending_tasks: Rc<RefCell<PendingTasks>>,
+    _marker_t: PhantomData<T>,
+    _marker_u: PhantomData<U>,
+}
+
+impl<RT, F, U: Data, T: Data> JobTracker<F, RT, U, T>
+where
+    F: SerFunc((TasKContext, Box<dyn Iterator<Item = T>>)) -> U,
+    RT: 'static + Rdd<T>,
+{
+    pub fn from_scheduler<S>(
+        scheduler: &S,
+        func: Arc<F>,
+        final_rdd: Arc<RT>,
+        output_parts: Vec<usize>,
+    ) -> JobTracker<F, RT, U, T>
+    where
+        RT: Rdd<T>,
+        S: SharedScheduler,
+    {
+        let run_id = scheduler.get_next_job_id();
+        let final_stage = scheduler.new_stage(final_rdd.clone(), None);
+        let threadpool = Rc::new(ThreadPool::new(scheduler.num_threads()));
+        JobTracker::new(
+            run_id,
+            final_stage,
+            func,
+            final_rdd,
+            output_parts,
+            threadpool,
+        )
+    }
+
+    fn new(
+        run_id: usize,
+        final_stage: Stage,
+        func: Arc<F>,
+        final_rdd: Arc<RT>,
+        output_parts: Vec<usize>,
+        thread_pool: Rc<ThreadPool>,
+    ) -> JobTracker<F, RT, U, T>
+    where
+        RT: Rdd<T>,
+    {
+        let finished: Vec<bool> = (0..output_parts.len()).map(|_| false).collect();
+        let mut pending_tasks: BTreeMap<Stage, BTreeSet<Box<dyn TaskBase>>> = BTreeMap::new();
+        JobTracker {
+            num_output_parts: output_parts.len(),
+            output_parts,
+            final_stage,
+            func,
+            final_rdd,
+            run_id,
+            thread_pool,
+            waiting: Rc::new(RefCell::new(BTreeSet::new())),
+            running: Rc::new(RefCell::new(BTreeSet::new())),
+            failed: Rc::new(RefCell::new(BTreeSet::new())),
+            finished: Rc::new(RefCell::new(finished)),
+            pending_tasks: Rc::new(RefCell::new(pending_tasks)),
+            _marker_t: PhantomData,
+            _marker_u: PhantomData,
+        }
+    }
+}
+
+impl<RT, F, U: Data, T: Data> Clone for JobTracker<F, RT, U, T>
+where
+    F: SerFunc((TasKContext, Box<dyn Iterator<Item = T>>)) -> U,
+    RT: 'static + Rdd<T>,
+{
+    fn clone(&self) -> Self {
+        JobTracker {
+            output_parts: self.output_parts.clone(),
+            num_output_parts: self.num_output_parts,
+            final_stage: self.final_stage.clone(),
+            func: self.func.clone(),
+            final_rdd: self.final_rdd.clone(),
+            run_id: self.run_id,
+            thread_pool: self.thread_pool.clone(),
+            waiting: self.waiting.clone(),
+            running: self.running.clone(),
+            failed: self.running.clone(),
+            finished: self.finished.clone(),
+            pending_tasks: self.pending_tasks.clone(),
+            _marker_t: PhantomData,
+            _marker_u: PhantomData,
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@ use shuffle_manager::*;
 mod shuffle_map_task;
 use shuffle_map_task::*;
 
+#[macro_use]
 mod scheduler;
 use scheduler::*;
 

--- a/src/local_scheduler.rs
+++ b/src/local_scheduler.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::job::JobTracker;
+use crate::scheduler::SharedScheduler;
 
 use std::any::Any;
 use std::cell::RefCell;
@@ -21,13 +23,13 @@ use threadpool::ThreadPool;
 
 #[derive(Clone, Default)]
 pub struct LocalScheduler {
-    threads: usize,
+    pub(crate) threads: usize,
     max_failures: usize,
     attempt_id: Arc<AtomicUsize>,
     resubmit_timeout: u128,
     poll_timeout: u64,
     event_queues: Arc<Mutex<HashMap<usize, VecDeque<CompletionEvent>>>>,
-    next_job_id: Arc<AtomicUsize>,
+    pub(crate) next_job_id: Arc<AtomicUsize>,
     next_run_id: Arc<AtomicUsize>,
     next_task_id: Arc<AtomicUsize>,
     next_stage_id: Arc<AtomicUsize>,
@@ -75,204 +77,7 @@ impl LocalScheduler {
         }
     }
 
-    fn get_cache_locs(&self, rdd: Arc<dyn RddBase>) -> Option<Vec<Vec<Ipv4Addr>>> {
-        let cache_locs = self.cache_locs.lock();
-        let locs_opt = cache_locs.get(&rdd.get_rdd_id());
-        match locs_opt {
-            Some(locs) => Some(locs.clone()),
-            None => None,
-        }
-    }
-
-    fn update_cache_locs(&self) {
-        let mut locs = self.cache_locs.lock();
-        *locs = env::env.cache_tracker.get_location_snapshot();
-    }
-
-    fn task_ended(
-        event_queues: Arc<Mutex<HashMap<usize, VecDeque<CompletionEvent>>>>,
-        task: Box<dyn TaskBase>,
-        reason: TastEndReason,
-        result: Box<dyn Any + Send + Sync>,
-        //TODO accumvalues needs to be done
-    ) {
-        let result = Some(result);
-        if let Some(queue) = event_queues.lock().get_mut(&(task.get_run_id())) {
-            queue.push_back(CompletionEvent {
-                task,
-                reason,
-                result,
-                accum_updates: HashMap::new(),
-            });
-        } else {
-            info!("ignoring completion event for DAG Job");
-        }
-    }
-
-    fn get_shuffle_map_stage(&self, shuf: Arc<dyn ShuffleDependencyTrait>) -> Stage {
-        info!("inside get_shufflemap stage");
-        let stage = match self.shuffle_to_map_stage.lock().get(&shuf.get_shuffle_id()) {
-            Some(s) => Some(s.clone()),
-            None => None,
-        };
-        match stage {
-            Some(stage) => stage.clone(),
-            None => {
-                info!("inside get_shufflemap stage before");
-                let stage = self.new_stage(shuf.get_rdd_base(), Some(shuf.clone()));
-                self.shuffle_to_map_stage
-                    .lock()
-                    .insert(shuf.get_shuffle_id(), stage.clone());
-                info!("inside get_shufflemap return");
-                stage
-            }
-        }
-    }
-
-    fn new_stage(
-        &self,
-        rdd_base: Arc<dyn RddBase>,
-        shuffle_dependency: Option<Arc<dyn ShuffleDependencyTrait>>,
-    ) -> Stage {
-        info!("inside new stage");
-        env::env
-            .cache_tracker
-            .register_rdd(rdd_base.get_rdd_id(), rdd_base.number_of_splits());
-        if shuffle_dependency.is_some() {
-            info!("shuffle dependency and registering mapoutput tracker");
-            self.map_output_tracker.register_shuffle(
-                shuffle_dependency.clone().unwrap().get_shuffle_id(),
-                rdd_base.number_of_splits(),
-            );
-            info!("new stage tracker after");
-        }
-        let id = self.next_stage_id.fetch_add(1, Ordering::SeqCst);
-        info!("new stage id {}", id);
-        let stage = Stage::new(
-            id,
-            rdd_base.clone(),
-            shuffle_dependency,
-            self.get_parent_stages(rdd_base),
-        );
-        self.id_to_stage.lock().insert(id, stage.clone());
-        info!("new stage stage return");
-        stage
-    }
-
-    fn visit_for_parent_stages(
-        &self,
-        parents: &mut BTreeSet<Stage>,
-        visited: &mut BTreeSet<Arc<dyn RddBase>>,
-        rdd: Arc<dyn RddBase>,
-    ) {
-        info!(
-            "parent stages {:?}",
-            parents.iter().map(|x| x.id).collect::<Vec<_>>()
-        );
-        info!(
-            "visisted stages {:?}",
-            visited.iter().map(|x| x.get_rdd_id()).collect::<Vec<_>>()
-        );
-        if !visited.contains(&rdd) {
-            visited.insert(rdd.clone());
-            env::env
-                .cache_tracker
-                .register_rdd(rdd.get_rdd_id(), rdd.number_of_splits());
-            for dep in rdd.get_dependencies() {
-                match dep {
-                    Dependency::ShuffleDependency(shuf_dep) => {
-                        parents.insert(self.get_shuffle_map_stage(shuf_dep.clone()));
-                    }
-                    Dependency::OneToOneDependency(oto_dep) => {
-                        self.visit_for_parent_stages(parents, visited, oto_dep.get_rdd_base())
-                    }
-                    Dependency::NarrowDependency(nar_dep) => {
-                        self.visit_for_parent_stages(parents, visited, nar_dep.get_rdd_base())
-                    } //TODO finish range dependency
-                }
-            }
-        }
-    }
-
-    fn get_parent_stages(&self, rdd: Arc<dyn RddBase>) -> Vec<Stage> {
-        info!("inside get parent stages");
-        let mut parents: BTreeSet<Stage> = BTreeSet::new();
-        let mut visited: BTreeSet<Arc<dyn RddBase>> = BTreeSet::new();
-        self.visit_for_parent_stages(&mut parents, &mut visited, rdd.clone());
-        info!(
-            "parent stages {:?}",
-            parents.iter().map(|x| x.id).collect::<Vec<_>>()
-        );
-        parents.into_iter().collect()
-    }
-
-    fn visit_for_missing_parent_stages(
-        &self,
-        missing: &mut BTreeSet<Stage>,
-        visited: &mut BTreeSet<Arc<dyn RddBase>>,
-        rdd: Arc<dyn RddBase>,
-    ) {
-        info!(
-            "missing stages {:?}",
-            missing.iter().map(|x| x.id).collect::<Vec<_>>()
-        );
-        info!(
-            "visisted stages {:?}",
-            visited.iter().map(|x| x.get_rdd_id()).collect::<Vec<_>>()
-        );
-        if !visited.contains(&rdd) {
-            visited.insert(rdd.clone());
-            // TODO CacheTracker register
-            for p in 0..rdd.number_of_splits() {
-                let locs = self.get_cache_locs(rdd.clone());
-                info!("cache locs {:?}", locs);
-                if locs == None {
-                    for dep in rdd.get_dependencies() {
-                        info!("for dep in missing stages ");
-                        match dep {
-                            Dependency::ShuffleDependency(shuf_dep) => {
-                                let stage = self.get_shuffle_map_stage(shuf_dep.clone());
-                                info!("shuffle stage in missing stages {:?}", stage.id);
-                                if !stage.is_available() {
-                                    info!(
-                                        "inserting shuffle stage in missing stages {:?}",
-                                        stage.id
-                                    );
-                                    missing.insert(stage);
-                                }
-                            }
-                            Dependency::NarrowDependency(nar_dep) => {
-                                info!("narrow stage in missing stages ");
-                                self.visit_for_missing_parent_stages(
-                                    missing,
-                                    visited,
-                                    nar_dep.get_rdd_base(),
-                                )
-                            }
-                            Dependency::OneToOneDependency(one_dep) => {
-                                info!("one to one stage in missing stages ");
-                                self.visit_for_missing_parent_stages(
-                                    missing,
-                                    visited,
-                                    one_dep.get_rdd_base(),
-                                )
-                            } //TODO finish range dependency
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    fn get_missing_parent_stages(&self, stage: Stage) -> Vec<Stage> {
-        info!("inside get missing parent stages");
-        let mut missing: BTreeSet<Stage> = BTreeSet::new();
-        let mut visited: BTreeSet<Arc<dyn RddBase>> = BTreeSet::new();
-        self.visit_for_missing_parent_stages(&mut missing, &mut visited, stage.get_rdd());
-        missing.into_iter().collect()
-    }
-
-    pub fn run_job<T: Data, U: Data, F>(
+    pub fn run_job<T: Data, U: Data, F, RT>(
         &self,
         func: Arc<F>,
         final_rdd: Arc<dyn Rdd<Item = T>>,
@@ -283,11 +88,11 @@ impl LocalScheduler {
         F: SerFunc((TasKContext, Box<dyn Iterator<Item = T>>)) -> U,
     {
         info!(
-            "shuffle maanger in final rdd of run job {:?}",
+            "shuffle manager in final rdd of run job {:?}",
             env::env.shuffle_manager
         );
 
-        let mut jt = JobTracker::new(self, func.clone(), final_rdd.clone(), partitions);
+        let mut jt = JobTracker::from_scheduler(self, func.clone(), final_rdd.clone(), partitions);
         let mut results: Vec<Option<U>> = (0..jt.num_output_parts).map(|_| None).collect();
         let mut num_finished = 0;
         let mut fetch_failure_duration = Duration::new(0, 0);
@@ -332,12 +137,9 @@ impl LocalScheduler {
                     .remove(&evt.task);
                 use super::dag_scheduler::TastEndReason::*;
                 match evt.reason {
-                    Success => self.on_event_success::<T, U, F>(
-                        evt,
-                        &mut results,
-                        &mut num_finished,
-                        jt.clone(),
-                    ),
+                    Success => {
+                        self.on_event_success(evt, &mut results, &mut num_finished, jt.clone())
+                    }
                     FetchFailed(failed_vals) => {
                         self.on_event_failure(jt.clone(), failed_vals, evt.task.get_stage_id());
                         fetch_failure_duration = start.elapsed();
@@ -370,310 +172,6 @@ impl LocalScheduler {
             .collect())
     }
 
-    fn on_event_success<T: Data, U: Data, F>(
-        &self,
-        mut completed_event: CompletionEvent,
-        results: &mut Vec<Option<U>>,
-        num_finished: &mut usize,
-        jt: JobTracker<F, U, T>,
-    ) where
-        F: SerFunc((TasKContext, Box<dyn Iterator<Item = T>>)) -> U,
-    {
-        //TODO logging
-        //TODO add to Accumulator
-
-        let mut result_type = completed_event
-            .task
-            .downcast_ref::<ResultTask<T, U, F>>()
-            .is_some();
-        if result_type {
-            if let Ok(rt) = completed_event.task.downcast::<ResultTask<T, U, F>>() {
-                let result = completed_event
-                    .result
-                    .take()
-                    .unwrap()
-                    .downcast_ref::<U>()
-                    .unwrap()
-                    .clone();
-
-                results[rt.output_id] = Some(result);
-                jt.finished.borrow_mut()[rt.output_id] = true;
-                *num_finished += 1;
-            }
-        } else if let Ok(smt) = completed_event.task.downcast::<ShuffleMapTask>() {
-            let result = completed_event
-                .result
-                .take()
-                .unwrap()
-                .downcast_ref::<String>()
-                .unwrap()
-                .clone();
-
-            info!("result inside queue {:?}", result);
-            self.id_to_stage
-                .lock()
-                .get_mut(&smt.stage_id)
-                .unwrap()
-                .add_output_loc(smt.partition, result);
-            let stage = self.id_to_stage.lock().clone()[&smt.stage_id].clone();
-            info!(
-                "pending stages {:?}",
-                jt.pending_tasks
-                    .borrow()
-                    .iter()
-                    .map(|(x, y)| (x.id, y.iter().map(|k| k.get_task_id()).collect::<Vec<_>>()))
-                    .collect::<Vec<_>>()
-            );
-            info!(
-                "pending tasks {:?}",
-                jt.pending_tasks
-                    .borrow()
-                    .get(&stage)
-                    .unwrap()
-                    .iter()
-                    .map(|x| x.get_task_id())
-                    .collect::<Vec<_>>()
-            );
-            info!(
-                "running {:?}",
-                jt.running.borrow().iter().map(|x| x.id).collect::<Vec<_>>()
-            );
-            info!(
-                "waiting {:?}",
-                jt.waiting.borrow().iter().map(|x| x.id).collect::<Vec<_>>()
-            );
-
-            if jt.running.borrow().contains(&stage)
-                && jt.pending_tasks.borrow().get(&stage).unwrap().is_empty()
-            {
-                info!("here before registering map outputs ");
-                //TODO logging
-                jt.running.borrow_mut().remove(&stage);
-                if stage.shuffle_dependency.is_some() {
-                    info!(
-                        "stage output locs before register mapoutput tracker {:?}",
-                        stage.output_locs
-                    );
-                    let locs = stage
-                        .output_locs
-                        .iter()
-                        .map(|x| match x.get(0) {
-                            Some(s) => Some(s.to_owned()),
-                            None => None,
-                        })
-                        .collect();
-                    info!(
-                        "locs for shuffle id {:?} {:?}",
-                        stage.clone().shuffle_dependency.unwrap().get_shuffle_id(),
-                        locs
-                    );
-                    self.map_output_tracker.register_map_outputs(
-                        stage.shuffle_dependency.unwrap().get_shuffle_id(),
-                        locs,
-                    );
-                    info!("here after registering map outputs ");
-                }
-                //TODO Cache
-                self.update_cache_locs();
-                let mut newly_runnable = Vec::new();
-                for stage in jt.waiting.borrow().iter() {
-                    info!(
-                        "waiting stage parent stages for stage {} are {:?}",
-                        stage.id,
-                        self.get_missing_parent_stages(stage.clone())
-                            .iter()
-                            .map(|x| x.id)
-                            .collect::<Vec<_>>()
-                    );
-                    if self.get_missing_parent_stages(stage.clone()).is_empty() {
-                        newly_runnable.push(stage.clone())
-                    }
-                }
-                for stage in &newly_runnable {
-                    jt.waiting.borrow_mut().remove(stage);
-                }
-                for stage in &newly_runnable {
-                    jt.running.borrow_mut().insert(stage.clone());
-                }
-                for stage in newly_runnable {
-                    self.submit_missing_tasks(stage, jt.clone());
-                }
-            }
-        }
-    }
-
-    fn on_event_failure<T: Data, U: Data, F>(
-        &self,
-        jt: JobTracker<F, U, T>,
-        failed_vals: FetchFailedVals,
-        stage_id: usize,
-    ) where
-        F: SerFunc((TasKContext, Box<dyn Iterator<Item = T>>)) -> U,
-    {
-        let FetchFailedVals {
-            server_uri,
-            shuffle_id,
-            map_id,
-            reduce_id,
-        } = failed_vals;
-
-        //TODO mapoutput tracker needs to be finished for this
-        let failed_stage = self.id_to_stage.lock().get(&stage_id).unwrap().clone();
-        jt.running.borrow_mut().remove(&failed_stage);
-        jt.failed.borrow_mut().insert(failed_stage);
-        //TODO logging
-        self.shuffle_to_map_stage
-            .lock()
-            .get_mut(&shuffle_id)
-            .unwrap()
-            .remove_output_loc(map_id, server_uri.clone());
-        self.map_output_tracker
-            .unregister_map_output(shuffle_id, map_id, server_uri.clone());
-        //logging
-        jt.failed.borrow_mut().insert(
-            self.shuffle_to_map_stage
-                .lock()
-                .get(&shuffle_id)
-                .unwrap()
-                .clone(),
-        );
-    }
-
-    /// Fast path for execution. Runs the DD in the driver main thread if possible.
-    fn local_execution<T: Data, U: Data, F>(
-        jt: JobTracker<F, U, T>,
-    ) -> Result<Option<Vec<U>>>
-    where
-        F: SerFunc((TasKContext, Box<dyn Iterator<Item = T>>)) -> U,
-    {
-        if jt.final_stage.parents.is_empty() && (jt.num_output_parts == 1) {
-            let split = (jt.final_rdd.splits()[jt.output_parts[0]]).clone();
-            let task_context = TasKContext::new(jt.final_stage.id, jt.output_parts[0], 0);
-            Ok(Some(vec![(&jt.func)((
-                task_context,
-                jt.final_rdd.iterator(split)?,
-            ))]))
-        } else {
-            Ok(None)
-        }
-    }
-
-    fn submit_stage<T: Data, U: Data, F>(&self, stage: Stage, jt: JobTracker<F, U, T>)
-    where
-        F: SerFunc((TasKContext, Box<dyn Iterator<Item = T>>)) -> U,
-    {
-        info!("submiting stage {}", stage.id);
-        if !jt.waiting.borrow().contains(&stage) && !jt.running.borrow().contains(&stage) {
-            let missing = self.get_missing_parent_stages(stage.clone());
-            info!(
-                "inside submit stage missing stages {:?}",
-                missing.iter().map(|x| x.id).collect::<Vec<_>>()
-            );
-            if missing.is_empty() {
-                self.submit_missing_tasks(stage.clone(), jt.clone());
-                jt.running.borrow_mut().insert(stage.clone());
-            } else {
-                for parent in missing {
-                    self.submit_stage(parent, jt.clone());
-                }
-                jt.waiting.borrow_mut().insert(stage.clone());
-            }
-        }
-    }
-
-    fn submit_missing_tasks<T: Data, U: Data, F>(
-        &self,
-        stage: Stage,
-        mut jt: JobTracker<F, U, T>,
-    ) where
-        F: SerFunc((TasKContext, Box<dyn Iterator<Item = T>>)) -> U,
-    {
-        let mut pending_tasks = jt.pending_tasks.borrow_mut();
-        let my_pending = pending_tasks
-            .entry(stage.clone())
-            .or_insert_with(BTreeSet::new);
-        if stage == jt.final_stage {
-            info!("final stage {}", stage.id);
-            let mut id_in_job = 0;
-            for (id, part) in jt.output_parts.iter().enumerate().take(jt.num_output_parts) {
-                let locs = self.get_preferred_locs(jt.final_rdd.get_rdd_base(), *part);
-                let result_task = ResultTask::new(
-                    self.next_task_id.fetch_add(1, Ordering::SeqCst),
-                    jt.run_id,
-                    jt.final_stage.id,
-                    jt.final_rdd.clone(),
-                    jt.func.clone(),
-                    *part,
-                    locs,
-                    id,
-                );
-                my_pending.insert(Box::new(result_task.clone()));
-                self.submit_task::<T, U, F>(
-                    TaskOption::ResultTask(Box::new(result_task)),
-                    id_in_job,
-                    jt.thread_pool.clone(),
-                );
-                id_in_job += 1;
-            }
-        } else {
-            let mut id_in_job = 0;
-            for p in 0..stage.num_partitions {
-                info!("shuffle_stage {}", stage.id);
-                if stage.output_locs[p].is_empty() {
-                    let locs = self.get_preferred_locs(stage.get_rdd(), p);
-                    info!("creating task for {} partition  {}", stage.id, p);
-                    let shuffle_map_task = ShuffleMapTask::new(
-                        self.next_task_id.fetch_add(1, Ordering::SeqCst),
-                        jt.run_id,
-                        stage.id,
-                        stage.rdd.clone(),
-                        stage.shuffle_dependency.clone().unwrap(),
-                        p,
-                        locs,
-                    );
-                    info!(
-                        "creating task for {} partition  {} and shuffle id {}",
-                        stage.id,
-                        p,
-                        shuffle_map_task.dep.get_shuffle_id()
-                    );
-                    my_pending.insert(Box::new(shuffle_map_task.clone()));
-                    self.submit_task::<T, U, F>(
-                        TaskOption::ShuffleMapTask(Box::new(shuffle_map_task)),
-                        id_in_job,
-                        jt.thread_pool.clone(),
-                    );
-                    id_in_job += 1;
-                }
-            }
-        }
-    }
-
-    fn get_preferred_locs(&self, rdd: Arc<dyn RddBase>, partition: usize) -> Vec<Ipv4Addr> {
-        //TODO have to implement this completely
-
-        if let Some(cached) = self.get_cache_locs(rdd.clone()) {
-            if let Some(cached) = cached.get(partition) {
-                return cached.clone();
-            }
-        }
-        let rdd_prefs = rdd.preferred_locations(rdd.splits()[partition].clone());
-        if !rdd_prefs.is_empty() {
-            return rdd_prefs;
-        }
-        for dep in rdd.get_dependencies().iter() {
-            if let Dependency::NarrowDependency(nar_dep) = dep {
-                for in_part in nar_dep.get_parents(partition) {
-                    let locs = self.get_preferred_locs(nar_dep.get_rdd_base(), in_part);
-                    if !locs.is_empty() {
-                        return locs;
-                    }
-                }
-            }
-        }
-        Vec::new()
-    }
-
     fn wait_for_event(&self, run_id: usize, timeout: u64) -> Option<CompletionEvent> {
         let end = Instant::now() + Duration::from_millis(timeout);
         while self.event_queues.lock().get(&run_id).unwrap().is_empty() {
@@ -690,24 +188,7 @@ impl LocalScheduler {
             .pop_front()
     }
 
-    fn submit_task<T: Data, U: Data, F>(
-        &self,
-        task: TaskOption,
-        id_in_job: usize,
-        thread_pool: Rc<ThreadPool>,
-    ) where
-        F: SerFunc((TasKContext, Box<dyn Iterator<Item = T>>)) -> U,
-    {
-        info!("inside submit task");
-        let my_attempt_id = self.attempt_id.fetch_add(1, Ordering::SeqCst);
-        let event_queues = self.event_queues.clone();
-        let task = bincode::serialize(&task).unwrap();
-        thread_pool.execute(move || {
-            LocalScheduler::run_task::<T, U, F>(event_queues, task, id_in_job, my_attempt_id)
-        });
-    }
-
-    fn run_task<T: Data, U: Data, F>(
+    fn run_task<T: Data, U: Data, RT, F>(
         event_queues: Arc<Mutex<HashMap<usize, VecDeque<CompletionEvent>>>>,
         task: Vec<u8>,
         id_in_job: usize,
@@ -750,83 +231,112 @@ impl LocalScheduler {
             }
         };
     }
-}
 
-type PendingTasks = BTreeMap<Stage, BTreeSet<Box<dyn TaskBase>>>;
-
-/// Contains all the necessary types to run and track a job progress
-struct JobTracker<F, U: Data, T: Data>
-where
-    F: SerFunc((TasKContext, Box<dyn Iterator<Item = T>>)) -> U,
-{
-    output_parts: Vec<usize>,
-    num_output_parts: usize,
-    final_stage: Stage,
-    func: Arc<F>,
-    final_rdd: Arc<dyn Rdd<Item = T>>,
-    run_id: usize,
-    thread_pool: Rc<ThreadPool>,
-    waiting: Rc<RefCell<BTreeSet<Stage>>>,
-    running: Rc<RefCell<BTreeSet<Stage>>>,
-    failed: Rc<RefCell<BTreeSet<Stage>>>,
-    finished: Rc<RefCell<Vec<bool>>>,
-    pending_tasks: Rc<RefCell<PendingTasks>>,
-    _marker_t: PhantomData<T>,
-    _marker_u: PhantomData<U>,
-}
-
-impl<F, U: Data, T: Data> JobTracker<F, U, T>
-where
-    F: SerFunc((TasKContext, Box<dyn Iterator<Item = T>>)) -> U,
-{
-    fn new(
-        scheduler: &LocalScheduler,
-        func: Arc<F>,
-        final_rdd: Arc<dyn Rdd<Item = T>>,
-        output_parts: Vec<usize>,
-    ) -> JobTracker<F, U, T> {
-        let run_id = scheduler.next_job_id.fetch_add(1, Ordering::SeqCst);
-        let finished: Vec<bool> = (0..output_parts.len()).map(|_| false).collect();
-        let mut pending_tasks: BTreeMap<Stage, BTreeSet<Box<dyn TaskBase>>> = BTreeMap::new();
-        JobTracker {
-            num_output_parts: output_parts.len(),
-            output_parts,
-            final_stage: scheduler.new_stage(final_rdd.get_rdd_base(), None),
-            func,
-            final_rdd,
-            run_id,
-            thread_pool: Rc::new(ThreadPool::new(scheduler.threads)),
-            waiting: Rc::new(RefCell::new(BTreeSet::new())),
-            running: Rc::new(RefCell::new(BTreeSet::new())),
-            failed: Rc::new(RefCell::new(BTreeSet::new())),
-            finished: Rc::new(RefCell::new(finished)),
-            pending_tasks: Rc::new(RefCell::new(pending_tasks)),
-            _marker_t: PhantomData,
-            _marker_u: PhantomData,
+    fn task_ended(
+        event_queues: Arc<Mutex<HashMap<usize, VecDeque<CompletionEvent>>>>,
+        task: Box<dyn TaskBase>,
+        reason: TastEndReason,
+        result: Box<dyn Any + Send + Sync>,
+        //TODO accumvalues needs to be done
+    ) {
+        let result = Some(result);
+        if let Some(queue) = event_queues.lock().get_mut(&(task.get_run_id())) {
+            queue.push_back(CompletionEvent {
+                task,
+                reason,
+                result,
+                accum_updates: HashMap::new(),
+            });
+        } else {
+            info!("ignoring completion event for DAG Job");
         }
     }
 }
 
-impl<F, U: Data, T: Data> Clone for JobTracker<F, U, T>
-where
-    F: SerFunc((TasKContext, Box<dyn Iterator<Item = T>>)) -> U,
-{
-    fn clone(&self) -> Self {
-        JobTracker {
-            output_parts: self.output_parts.clone(),
-            num_output_parts: self.num_output_parts,
-            final_stage: self.final_stage.clone(),
-            func: self.func.clone(),
-            final_rdd: self.final_rdd.clone(),
-            run_id: self.run_id,
-            thread_pool: self.thread_pool.clone(),
-            waiting: self.waiting.clone(),
-            running: self.running.clone(),
-            failed: self.running.clone(),
-            finished: self.finished.clone(),
-            pending_tasks: self.pending_tasks.clone(),
-            _marker_t: PhantomData,
-            _marker_u: PhantomData,
+impl SharedScheduler for LocalScheduler {
+    /// Every single task in run in the local thread pool
+    fn submit_task<T: Data, U: Data, RT, F>(
+        &self,
+        task: TaskOption,
+        id_in_job: usize,
+        thread_pool: Rc<ThreadPool>,
+    ) where
+        F: SerFunc((TasKContext, Box<dyn Iterator<Item = T>>)) -> U,
+        RT: Rdd<T> + 'static,
+    {
+        info!("inside submit task");
+        let my_attempt_id = self.attempt_id.fetch_add(1, Ordering::SeqCst);
+        let event_queues = self.event_queues.clone();
+        let task = bincode::serialize(&task).unwrap();
+        thread_pool.execute(move || {
+            LocalScheduler::run_task::<T, U, RT, F>(event_queues, task, id_in_job, my_attempt_id)
+        });
+    }
+
+    fn insert_into_stage_cache(&mut self, id: usize, stage: Stage) {
+        self.id_to_stage.lock().insert(id, stage.clone());
+    }
+
+    fn register_shuffle(&mut self, shuffle_id: usize, num_maps: usize) {
+        self.map_output_tracker
+            .register_shuffle(shuffle_id, num_maps);
+    }
+
+    fn update_cache_locs(&self) {
+        let mut locs = self.cache_locs.lock();
+        *locs = env::env.cache_tracker.get_location_snapshot();
+    }
+
+    fn get_cache_locs(&self, rdd: Arc<dyn RddBase>) -> Option<Vec<Vec<Ipv4Addr>>> {
+        let cache_locs = self.cache_locs.lock();
+        let locs_opt = cache_locs.get(&rdd.get_rdd_id());
+        match locs_opt {
+            Some(locs) => Some(locs.clone()),
+            None => None,
         }
+    }
+
+    fn get_next_job_id(&self) -> usize {
+        self.next_job_id.fetch_add(1, Ordering::SeqCst)
+    }
+
+    fn get_next_stage_id(&self) -> usize {
+        self.next_stage_id.fetch_add(1, Ordering::SeqCst)
+    }
+
+    fn get_next_task_id(&self) -> usize {
+        self.next_task_id.fetch_add(1, Ordering::SeqCst)
+    }
+
+    fn get_missing_parent_stages(&self, stage: Stage) -> Vec<Stage> {
+        info!("inside get missing parent stages");
+        let mut missing: BTreeSet<Stage> = BTreeSet::new();
+        let mut visited: BTreeSet<Arc<dyn RddBase>> = BTreeSet::new();
+        self.visit_for_missing_parent_stages(&mut missing, &mut visited, stage.get_rdd());
+        missing.into_iter().collect()
+    }
+
+    fn get_shuffle_map_stage(&self, shuf: Arc<dyn ShuffleDependencyTrait>) -> Stage {
+        info!("inside get_shufflemap stage");
+        let stage = match self.shuffle_to_map_stage.lock().get(&shuf.get_shuffle_id()) {
+            Some(s) => Some(s.clone()),
+            None => None,
+        };
+        match stage {
+            Some(stage) => stage.clone(),
+            None => {
+                info!("inside get_shufflemap stage before");
+                let stage = self.new_stage(shuf.get_rdd_base(), Some(shuf.clone()));
+                self.shuffle_to_map_stage
+                    .lock()
+                    .insert(shuf.get_shuffle_id(), stage.clone());
+                info!("inside get_shufflemap return");
+                stage
+            }
+        }
+    }
+
+    fn num_threads(&self) -> usize {
+        self.threads
     }
 }

--- a/src/map_output_tracker.rs
+++ b/src/map_output_tracker.rs
@@ -235,8 +235,8 @@ impl MapOutputTracker {
             .iter()
             .filter(|x| !x.is_none())
             .map(|x| x.clone().unwrap())
-            .collect::<Vec<_>>()
-            .is_empty()
+            .next()
+            .is_none()
         {
             // if self.server_uris.read().get(&shuffle_id).is_empty(){
             if self.fetching.read().contains(&shuffle_id) {
@@ -282,15 +282,14 @@ impl MapOutputTracker {
 
             fetched
         } else {
-            return self
-                .server_uris
+            self.server_uris
                 .read()
                 .get(&shuffle_id)
                 .unwrap()
                 .iter()
                 .filter(|x| !x.is_none())
                 .map(|x| x.clone().unwrap())
-                .collect();
+                .collect()
         }
     }
 

--- a/src/rdd/mod.rs
+++ b/src/rdd/mod.rs
@@ -1,3 +1,4 @@
+use serde_traitobject::Arc as SerArc;
 use std::cmp::Ordering;
 use std::fs;
 use std::hash::Hash;
@@ -6,7 +7,6 @@ use std::marker::PhantomData;
 use std::net::Ipv4Addr;
 use std::path::Path;
 use std::sync::Arc;
-use serde_traitobject::Arc as SerArc;
 
 use log::info;
 use rand::{RngCore, SeedableRng};

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -1,5 +1,9 @@
 use super::*;
 
+use std::collections::{BTreeMap, BTreeSet};
+use std::net::Ipv4Addr;
+use std::sync::Arc;
+
 pub trait Scheduler {
     fn start(&self);
     fn wait_for_register(&self);
@@ -16,4 +20,478 @@ pub trait Scheduler {
         F: Fn(Box<dyn Iterator<Item = T>>) -> U;
     fn stop(&self);
     fn default_parallelism(&self) -> i64;
+}
+
+/// Functionality by the library built-in schedulers
+pub(crate) trait SharedScheduler {
+    /// Fast path for execution. Runs the DD in the driver main thread if possible.
+    fn local_execution<T: Data, U: Data, F, RT>(
+        jt: JobTracker<F, RT, U, T>,
+    ) -> Result<Option<Vec<U>>>
+    where
+        F: SerFunc((TasKContext, Box<dyn Iterator<Item = T>>)) -> U,
+        RT: Rdd<T> + 'static,
+    {
+        if jt.final_stage.parents.is_empty() && (jt.num_output_parts == 1) {
+            let split = (jt.final_rdd.splits()[jt.output_parts[0]]).clone();
+            let task_context = TasKContext::new(jt.final_stage.id, jt.output_parts[0], 0);
+            Ok(Some(vec![(&jt.func)((
+                task_context,
+                jt.final_rdd.iterator(split)?,
+            ))]))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn new_stage(
+        &mut self,
+        rdd_base: Arc<dyn RddBase>,
+        shuffle_dependency: Option<Arc<dyn ShuffleDependencyTrait>>,
+    ) -> Stage {
+        info!("inside new stage");
+        env::env
+            .cache_tracker
+            .register_rdd(rdd_base.get_rdd_id(), rdd_base.number_of_splits());
+        if shuffle_dependency.is_some() {
+            info!("shuffle dependency and registering mapoutput tracker");
+            self.register_shuffle(
+                shuffle_dependency.clone().unwrap().get_shuffle_id(),
+                rdd_base.number_of_splits(),
+            );
+            info!("new stage tracker after");
+        }
+        let id = self.get_next_stage_id();
+        info!("new stage id {}", id);
+        let stage = Stage::new(
+            id,
+            rdd_base.clone(),
+            shuffle_dependency,
+            self.get_parent_stages(rdd_base),
+        );
+        self.insert_into_stage_cache(id, stage.clone());
+        info!("new stage stage return");
+        stage
+    }
+
+    fn visit_for_missing_parent_stages(
+        &self,
+        missing: &mut BTreeSet<Stage>,
+        visited: &mut BTreeSet<Arc<dyn RddBase>>,
+        rdd: Arc<dyn RddBase>,
+    ) {
+        info!(
+            "missing stages {:?}",
+            missing.iter().map(|x| x.id).collect::<Vec<_>>()
+        );
+        info!(
+            "visisted stages {:?}",
+            visited.iter().map(|x| x.get_rdd_id()).collect::<Vec<_>>()
+        );
+        if !visited.contains(&rdd) {
+            visited.insert(rdd.clone());
+            // TODO CacheTracker register
+            for p in 0..rdd.number_of_splits() {
+                let locs = self.get_cache_locs(rdd.clone());
+                info!("cache locs {:?}", locs);
+                if locs == None {
+                    for dep in rdd.get_dependencies() {
+                        info!("for dep in missing stages ");
+                        match dep {
+                            Dependency::ShuffleDependency(shuf_dep) => {
+                                let stage = self.get_shuffle_map_stage(shuf_dep.clone());
+                                info!("shuffle stage in missing stages {:?}", stage.id);
+                                if !stage.is_available() {
+                                    info!(
+                                        "inserting shuffle stage in missing stages {:?}",
+                                        stage.id
+                                    );
+                                    missing.insert(stage);
+                                }
+                            }
+                            Dependency::NarrowDependency(nar_dep) => {
+                                info!("narrow stage in missing stages ");
+                                self.visit_for_missing_parent_stages(
+                                    missing,
+                                    visited,
+                                    nar_dep.get_rdd_base(),
+                                )
+                            }
+                            Dependency::OneToOneDependency(one_dep) => {
+                                info!("one to one stage in missing stages ");
+                                self.visit_for_missing_parent_stages(
+                                    missing,
+                                    visited,
+                                    one_dep.get_rdd_base(),
+                                )
+                            } //TODO finish range dependency
+                        }
+                    }
+                }
+            }
+        }
+    }
+    fn visit_for_parent_stages(
+        &self,
+        parents: &mut BTreeSet<Stage>,
+        visited: &mut BTreeSet<Arc<dyn RddBase>>,
+        rdd: Arc<dyn RddBase>,
+    ) {
+        info!(
+            "parent stages {:?}",
+            parents.iter().map(|x| x.id).collect::<Vec<_>>()
+        );
+        info!(
+            "visisted stages {:?}",
+            visited.iter().map(|x| x.get_rdd_id()).collect::<Vec<_>>()
+        );
+        if !visited.contains(&rdd) {
+            visited.insert(rdd.clone());
+            env::env
+                .cache_tracker
+                .register_rdd(rdd.get_rdd_id(), rdd.number_of_splits());
+            for dep in rdd.get_dependencies() {
+                match dep {
+                    Dependency::ShuffleDependency(shuf_dep) => {
+                        parents.insert(self.get_shuffle_map_stage(shuf_dep.clone()));
+                    }
+                    Dependency::OneToOneDependency(oto_dep) => {
+                        self.visit_for_parent_stages(parents, visited, oto_dep.get_rdd_base())
+                    }
+                    Dependency::NarrowDependency(nar_dep) => {
+                        self.visit_for_parent_stages(parents, visited, nar_dep.get_rdd_base())
+                    } //TODO finish range dependency
+                }
+            }
+        }
+    }
+
+    fn get_parent_stages(&self, rdd: Arc<dyn RddBase>) -> Vec<Stage> {
+        info!("inside get parent stages");
+        let mut parents: BTreeSet<Stage> = BTreeSet::new();
+        let mut visited: BTreeSet<Arc<dyn RddBase>> = BTreeSet::new();
+        self.visit_for_parent_stages(&mut parents, &mut visited, rdd.clone());
+        info!(
+            "parent stages {:?}",
+            parents.iter().map(|x| x.id).collect::<Vec<_>>()
+        );
+        parents.into_iter().collect()
+    }
+
+    fn on_event_failure<T: Data, U: Data, F, RT>(
+        &self,
+        jt: JobTracker<F, RT, U, T>,
+        failed_vals: FetchFailedVals,
+        stage_id: usize,
+    ) where
+        F: SerFunc((TasKContext, Box<dyn Iterator<Item = T>>)) -> U,
+        RT: Rdd<T> + 'static,
+    {
+        let FetchFailedVals {
+            server_uri,
+            shuffle_id,
+            map_id,
+            reduce_id,
+        } = failed_vals;
+
+        //TODO mapoutput tracker needs to be finished for this
+        let failed_stage = self.id_to_stage.lock().get(&stage_id).unwrap().clone();
+        jt.running.borrow_mut().remove(&failed_stage);
+        jt.failed.borrow_mut().insert(failed_stage);
+        //TODO logging
+        self.shuffle_to_map_stage
+            .lock()
+            .get_mut(&shuffle_id)
+            .unwrap()
+            .remove_output_loc(map_id, server_uri.clone());
+        self.map_output_tracker
+            .unregister_map_output(shuffle_id, map_id, server_uri.clone());
+        //logging
+        jt.failed.borrow_mut().insert(
+            self.shuffle_to_map_stage
+                .lock()
+                .get(&shuffle_id)
+                .unwrap()
+                .clone(),
+        );
+    }
+
+    fn on_event_success<T: Data, U: Data, F, RT>(
+        &self,
+        mut completed_event: CompletionEvent,
+        results: &mut Vec<Option<U>>,
+        num_finished: &mut usize,
+        jt: JobTracker<F, RT, U, T>,
+    ) where
+        F: SerFunc((TasKContext, Box<dyn Iterator<Item = T>>)) -> U,
+        RT: Rdd<T> + 'static,
+    {
+        //TODO logging
+        //TODO add to Accumulator
+
+        let mut result_type = completed_event
+            .task
+            .downcast_ref::<ResultTask<T, U, RT, F>>()
+            .is_some();
+        if result_type {
+            if let Ok(rt) = completed_event.task.downcast::<ResultTask<T, U, RT, F>>() {
+                let result = completed_event
+                    .result
+                    .take()
+                    .unwrap()
+                    .downcast_ref::<U>()
+                    .unwrap()
+                    .clone();
+
+                results[rt.output_id] = Some(result);
+                jt.finished.borrow_mut()[rt.output_id] = true;
+                *num_finished += 1;
+            }
+        } else if let Ok(smt) = completed_event.task.downcast::<ShuffleMapTask>() {
+            let result = completed_event
+                .result
+                .take()
+                .unwrap()
+                .downcast_ref::<String>()
+                .unwrap()
+                .clone();
+
+            info!("result inside queue {:?}", result);
+            self.id_to_stage
+                .lock()
+                .get_mut(&smt.stage_id)
+                .unwrap()
+                .add_output_loc(smt.partition, result);
+            let stage = self.id_to_stage.lock().clone()[&smt.stage_id].clone();
+            info!(
+                "pending stages {:?}",
+                jt.pending_tasks
+                    .borrow()
+                    .iter()
+                    .map(|(x, y)| (x.id, y.iter().map(|k| k.get_task_id()).collect::<Vec<_>>()))
+                    .collect::<Vec<_>>()
+            );
+            info!(
+                "pending tasks {:?}",
+                jt.pending_tasks
+                    .borrow()
+                    .get(&stage)
+                    .unwrap()
+                    .iter()
+                    .map(|x| x.get_task_id())
+                    .collect::<Vec<_>>()
+            );
+            info!(
+                "running {:?}",
+                jt.running.borrow().iter().map(|x| x.id).collect::<Vec<_>>()
+            );
+            info!(
+                "waiting {:?}",
+                jt.waiting.borrow().iter().map(|x| x.id).collect::<Vec<_>>()
+            );
+
+            if jt.running.borrow().contains(&stage)
+                && jt.pending_tasks.borrow().get(&stage).unwrap().is_empty()
+            {
+                info!("here before registering map outputs ");
+                //TODO logging
+                jt.running.borrow_mut().remove(&stage);
+                if stage.shuffle_dependency.is_some() {
+                    info!(
+                        "stage output locs before register mapoutput tracker {:?}",
+                        stage.output_locs
+                    );
+                    let locs = stage
+                        .output_locs
+                        .iter()
+                        .map(|x| match x.get(0) {
+                            Some(s) => Some(s.to_owned()),
+                            None => None,
+                        })
+                        .collect();
+                    info!(
+                        "locs for shuffle id {:?} {:?}",
+                        stage.clone().shuffle_dependency.unwrap().get_shuffle_id(),
+                        locs
+                    );
+                    self.map_output_tracker.register_map_outputs(
+                        stage.shuffle_dependency.unwrap().get_shuffle_id(),
+                        locs,
+                    );
+                    info!("here after registering map outputs ");
+                }
+                //TODO Cache
+                self.update_cache_locs();
+                let mut newly_runnable = Vec::new();
+                for stage in jt.waiting.borrow().iter() {
+                    info!(
+                        "waiting stage parent stages for stage {} are {:?}",
+                        stage.id,
+                        self.get_missing_parent_stages(stage.clone())
+                            .iter()
+                            .map(|x| x.id)
+                            .collect::<Vec<_>>()
+                    );
+                    if self.get_missing_parent_stages(stage.clone()).is_empty() {
+                        newly_runnable.push(stage.clone())
+                    }
+                }
+                for stage in &newly_runnable {
+                    jt.waiting.borrow_mut().remove(stage);
+                }
+                for stage in &newly_runnable {
+                    jt.running.borrow_mut().insert(stage.clone());
+                }
+                for stage in newly_runnable {
+                    self.submit_missing_tasks(stage, jt.clone());
+                }
+            }
+        }
+    }
+
+    fn submit_stage<T: Data, U: Data, F, RT>(&self, stage: Stage, jt: JobTracker<F, RT, U, T>)
+    where
+        F: SerFunc((TasKContext, Box<dyn Iterator<Item = T>>)) -> U,
+        RT: Rdd<T> + 'static,
+    {
+        info!("submiting stage {}", stage.id);
+        if !jt.waiting.borrow().contains(&stage) && !jt.running.borrow().contains(&stage) {
+            let missing = self.get_missing_parent_stages(stage.clone());
+            info!(
+                "inside submit stage missing stages {:?}",
+                missing.iter().map(|x| x.id).collect::<Vec<_>>()
+            );
+            if missing.is_empty() {
+                self.submit_missing_tasks(stage.clone(), jt.clone());
+                jt.running.borrow_mut().insert(stage.clone());
+            } else {
+                for parent in missing {
+                    self.submit_stage(parent, jt.clone());
+                }
+                jt.waiting.borrow_mut().insert(stage.clone());
+            }
+        }
+    }
+
+    fn submit_missing_tasks<T: Data, U: Data, F, RT>(
+        &self,
+        stage: Stage,
+        mut jt: JobTracker<F, RT, U, T>,
+    ) where
+        F: SerFunc((TasKContext, Box<dyn Iterator<Item = T>>)) -> U,
+        RT: Rdd<T> + 'static,
+    {
+        let mut pending_tasks = jt.pending_tasks.borrow_mut();
+        let my_pending = pending_tasks
+            .entry(stage.clone())
+            .or_insert_with(BTreeSet::new);
+        if stage == jt.final_stage {
+            info!("final stage {}", stage.id);
+            let mut id_in_job = 0;
+            for (id, part) in jt.output_parts.iter().enumerate().take(jt.num_output_parts) {
+                let locs = self.get_preferred_locs(jt.final_rdd.clone() as Arc<dyn RddBase>, *part);
+                let result_task = ResultTask::new(
+                    self.get_next_task_id(),
+                    jt.run_id,
+                    jt.final_stage.id,
+                    jt.final_rdd.clone(),
+                    jt.func.clone(),
+                    *part,
+                    locs,
+                    id,
+                );
+                my_pending.insert(Box::new(result_task.clone()));
+                self.submit_task::<T, U, RT, F>(
+                    TaskOption::ResultTask(Box::new(result_task)),
+                    id_in_job,
+                    jt.thread_pool.clone(),
+                );
+                id_in_job += 1;
+            }
+        } else {
+            let mut id_in_job = 0;
+            for p in 0..stage.num_partitions {
+                info!("shuffle_stage {}", stage.id);
+                if stage.output_locs[p].is_empty() {
+                    let locs = self.get_preferred_locs(stage.get_rdd(), p);
+                    info!("creating task for {} partition  {}", stage.id, p);
+                    let shuffle_map_task = ShuffleMapTask::new(
+                        self.get_next_task_id(),
+                        jt.run_id,
+                        stage.id,
+                        stage.rdd.clone(),
+                        stage.shuffle_dependency.clone().unwrap(),
+                        p,
+                        locs,
+                    );
+                    info!(
+                        "creating task for {} partition  {} and shuffle id {}",
+                        stage.id,
+                        p,
+                        shuffle_map_task.dep.get_shuffle_id()
+                    );
+                    my_pending.insert(Box::new(shuffle_map_task.clone()));
+                    self.submit_task::<T, U, RT, F>(
+                        TaskOption::ShuffleMapTask(Box::new(shuffle_map_task)),
+                        id_in_job,
+                        jt.thread_pool.clone(),
+                    );
+                    id_in_job += 1;
+                }
+            }
+        }
+    }
+
+    fn submit_task<T: Data, U: Data, RT, F>(
+        &self,
+        task: TaskOption,
+        id_in_job: usize,
+        thread_pool: Rc<ThreadPool>,
+    ) where
+        F: SerFunc((TasKContext, Box<dyn Iterator<Item = T>>)) -> U,
+        RT: Rdd<T> + 'static;
+
+    // setters:
+    fn insert_into_stage_cache(&mut self, id: usize, stage: Stage);
+    fn register_shuffle(&mut self, shuffle_id: usize, num_maps: usize);
+    /// refreshes cache locations
+    fn update_cache_locs(&self);
+
+    // getters:
+    fn get_cache_locs(&self, rdd: Arc<dyn RddBase>) -> Option<Vec<Vec<Ipv4Addr>>>;
+    fn get_missing_parent_stages(&self, stage: Stage) -> Vec<Stage>;
+    fn get_next_job_id(&self) -> usize;
+    fn get_next_stage_id(&self) -> usize;
+    fn get_next_task_id(&self) -> usize;
+
+    fn get_preferred_locs(&self, rdd: Arc<dyn RddBase>, partition: usize) -> Vec<Ipv4Addr> {
+        //TODO have to implement this completely
+
+        if let Some(cached) = self.get_cache_locs(rdd.clone()) {
+            if let Some(cached) = cached.get(partition) {
+                return cached.clone();
+            }
+        }
+        let rdd_prefs = rdd.preferred_locations(rdd.splits()[partition].clone());
+        if !rdd_prefs.is_empty() {
+            return rdd_prefs;
+        }
+        for dep in rdd.get_dependencies().iter() {
+            if let Dependency::NarrowDependency(nar_dep) = dep {
+                for in_part in nar_dep.get_parents(partition) {
+                    let locs = self.get_preferred_locs(nar_dep.get_rdd_base(), in_part);
+                    if !locs.is_empty() {
+                        return locs;
+                    }
+                }
+            }
+        }
+        Vec::new()
+    }
+
+    fn get_shuffle_map_stage(&self, shuf: Arc<dyn ShuffleDependencyTrait>) -> Stage;
+
+    fn num_threads(&self) -> usize {
+        num_cpus::get()
+    }
 }

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -94,12 +94,12 @@ impl Stage {
         self.output_locs[partition].push(host);
     }
 
-    pub fn remove_output_loc(&mut self, partition: usize, host: String) {
+    pub fn remove_output_loc(&mut self, partition: usize, host: &str) {
         let prev_vec = self.output_locs[partition].clone();
         let new_vec = prev_vec
             .clone()
             .into_iter()
-            .filter(|x| x != &host)
+            .filter(|x| x != host)
             .collect::<Vec<_>>();
         if (!prev_vec.is_empty()) && (new_vec.is_empty()) {
             self.num_available_outputs -= 1;


### PR DESCRIPTION
Refactored local and distributed scheduler to extract most common functionality and made it everything more maintanable; removed duplicity and code surface.

With this change it should be easier to progress and complete work on the DAGScheduler and Scheduler traits. I didn't change any of those as I am not sure what do you want to expose in the public API yet, but in any case should be fairly easy to change things around. 

The refactor was made using a new non-leaking trait (NativeScheduler) which could be temporal until everything is moved to any of the other two traits.

Tests pass both in local and distributed mode.