### PR TITLE
add count by value

### DIFF
--- a/src/rdd/rdd.rs
+++ b/src/rdd/rdd.rs
@@ -420,15 +420,13 @@ pub trait Rdd: RddBase + 'static {
             .sum())
     }
 
+    /// Return the count of each unique value in this RDD as a dictionary of (value, count) pairs.	
     fn count_by_value(&self) -> SerArc<dyn Rdd<Item = (Self::Item, u64)>>
     where
         Self: Sized,
         Self::Item: Data + Eq + Hash,
     {
-        self.map(Box::new(Fn!(|x| (x, 1u64)))
-            as Box<
-                dyn Func(Self::Item) -> (Self::Item, u64),
-            >)
+        self.map(Fn!(|x| (x, 1u64)))
         .reduce_by_key(Box::new(Fn!(|(x, y)| x + y))
             as Box<
                 dyn Func((u64, u64)) -> u64,

--- a/src/rdd/rdd.rs
+++ b/src/rdd/rdd.rs
@@ -420,6 +420,21 @@ pub trait Rdd: RddBase + 'static {
             .sum())
     }
 
+    fn count_by_value(&self) -> SerArc<dyn Rdd<Item = (Self::Item, u64)>>
+    where
+        Self: Sized,
+        Self::Item: Data + Eq + Hash,
+    {
+        self.map(Box::new(Fn!(|x| (x, 1u64)))
+            as Box<
+                dyn Func(Self::Item) -> (Self::Item, u64),
+            >)
+        .reduce_by_key(Box::new(Fn!(|(x, y)| x + y))
+            as Box<
+                dyn Func((u64, u64)) -> u64,
+            >, self.number_of_splits())
+    }
+
     /// Return a new RDD containing the distinct elements in this RDD.
     fn distinct_with_num_partitions(
         &self,

--- a/tests/test_rdd.rs
+++ b/tests/test_rdd.rs
@@ -458,3 +458,17 @@ fn test_intersection() {
     let expected = vec![3, 4, 5, 13];
     assert_eq!(res, expected);
 }
+
+#[test]
+fn test_count_by_value() -> Result<()> {
+    let sc = CONTEXT.clone();
+
+    let rdd = sc.parallelize(vec![1i32, 2, 1, 2, 2], 2);
+    let rdd = rdd.count_by_value();
+    let res = rdd.collect().unwrap();
+
+    assert_eq!(res.len(), 2);
+    itertools::assert_equal(res, vec![(1, 2), (2, 3)]);
+
+    Ok(())
+}


### PR DESCRIPTION
use rdd.map(x => (x, 1L)).reduceByKey(_ + _) instead of countByKey() as hinted by [comments](https://github.com/apache/spark/blob/master/core/src/main/scala/org/apache/spark/rdd/RDD.scala#L1269) in spark 