### PR TITLE
Fixes and improvements for distributed mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ aws_connectors = ["rusoto_core", "rusoto_s3"]
 [dependencies]
 crossbeam = "0.7.3"
 dashmap = "^3.5.1"
+envy = "^0.4.1"
 fasthash = "0.4.0"
 futures = "0.3"
 hyper = "0.13.2"
@@ -55,10 +56,6 @@ serde_traitobject = "0.2.4"
 ## aws
 rusoto_core = { version = "0.42", optional = true }
 rusoto_s3 = { version = "0.42", optional = true }
-
-[dependencies.clap]
-version = "2.33"
-default-features = false
 
 [build-dependencies]
 capnpc = "0.12.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,6 @@ name = "native_spark"
 aws_connectors = ["rusoto_core", "rusoto_s3"]
 
 [dependencies]
-# temporal until tokio implements futures::AsyncRead/Write :
-async-std = { version = "1.5.0", features = ["attributes"] } 
 crossbeam = "0.7.3"
 dashmap = "^3.5.1"
 envy = "^0.4.1"
@@ -32,6 +30,7 @@ thiserror = "1.0.13"
 threadpool = "1.7.1"
 toml = "0.5.6"
 tokio = { version = "^0.2", features = ["rt-threaded", "stream", "sync", "time"] }
+tokio-util = { version = "0.3.1", features = ["compat"] }
 uuid = { version = "0.8", features = ["v4"] }
 regex = "1.3.6"
 
@@ -63,6 +62,7 @@ rusoto_s3 = { version = "0.43", optional = true }
 capnpc = "0.12.1"
 
 [dev-dependencies]
+async-std = { version = "1.5.0", features = ["attributes"] } 
 chrono = "0.4.11"
 parquet = "0.15.1"
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,25 +13,27 @@ name = "native_spark"
 aws_connectors = ["rusoto_core", "rusoto_s3"]
 
 [dependencies]
+# temporal until tokio implements futures::AsyncRead/Write :
+async-std = { version = "1.5.0", features = ["attributes"] } 
 crossbeam = "0.7.3"
 dashmap = "^3.5.1"
 envy = "^0.4.1"
 fasthash = "0.4.0"
 futures = "0.3"
 hyper = "0.13.4"
-http = "0.2.0"
+http = "0.2.1"
 itertools = "0.9.0"
 num_cpus = "1.12.0"
 log = "0.4.8"
 once_cell = "1.3.1"
 parking_lot = { version = "0.10.0", features = ["serde"] }
 simplelog = "0.7.4"
-thiserror = "1.0.12"
+thiserror = "1.0.13"
 threadpool = "1.7.1"
 toml = "0.5.6"
 tokio = { version = "^0.2", features = ["rt-threaded", "stream", "sync", "time"] }
 uuid = { version = "0.8", features = ["v4"] }
-regex = "1.3.5"
+regex = "1.3.6"
 
 # randomness
 rand = "0.7.3"
@@ -61,8 +63,7 @@ rusoto_s3 = { version = "0.43", optional = true }
 capnpc = "0.12.1"
 
 [dev-dependencies]
-async-std = { version = "1.5.0", features = ["attributes"] }
-chrono = "0.4.10"
+chrono = "0.4.11"
 parquet = "0.15.1"
 tempfile = "3"
 tokio = { version = "^0.2", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,20 +18,20 @@ dashmap = "^3.5.1"
 envy = "^0.4.1"
 fasthash = "0.4.0"
 futures = "0.3"
-hyper = "0.13.2"
+hyper = "0.13.4"
 http = "0.2.0"
-itertools = "0.8.2"
+itertools = "0.9.0"
 num_cpus = "1.12.0"
 log = "0.4.8"
 once_cell = "1.3.1"
 parking_lot = { version = "0.10.0", features = ["serde"] }
 simplelog = "0.7.4"
-thiserror = "1.0.11"
+thiserror = "1.0.12"
 threadpool = "1.7.1"
 toml = "0.5.6"
 tokio = { version = "^0.2", features = ["rt-threaded", "stream", "sync", "time"] }
 uuid = { version = "0.8", features = ["v4"] }
-regex = "1.3.4"
+regex = "1.3.5"
 
 # randomness
 rand = "0.7.3"
@@ -42,9 +42,9 @@ rand_pcg = "0.2"
 bincode = "1.2.1"
 capnp = "0.12.1"
 capnp-futures = "0.12.0"
-serde = { version = "1.0.104", features = ["rc"] }
+serde = { version = "1.0.105", features = ["rc"] }
 serde_closure = "^0.2.9"
-serde_derive = "1.0.104"
+serde_derive = "1.0.105"
 uriparse = "0.6.1"
 
 # dynamic typing
@@ -54,8 +54,8 @@ serde_traitobject = "0.2.4"
 
 # optional features
 ## aws
-rusoto_core = { version = "0.42", optional = true }
-rusoto_s3 = { version = "0.42", optional = true }
+rusoto_core = { version = "0.43", optional = true }
+rusoto_s3 = { version = "0.43", optional = true }
 
 [build-dependencies]
 capnpc = "0.12.1"

--- a/docker/testing_cluster.sh
+++ b/docker/testing_cluster.sh
@@ -29,12 +29,16 @@ do
     bash -c 'echo "$CONF_FILE" >> hosts.conf && \
     echo "NS_LOCAL_IP=$NS_LOCAL_IP" >> .ssh/environment && \
     echo "PermitUserEnvironment yes" >> /etc/ssh/sshd_config && \
+    echo "AcceptEnv RUST_BACKTRACE" >> /etc/ssh/sshd_config && \
     service ssh start';
     (( count++ ));
 done
 
 docker exec -e CONF_FILE="$CONF_FILE" -e NS_LOCAL_IP="${MASTER_IP}" -w /root/ docker_ns_master_1 \
-    bash -c 'echo "$CONF_FILE" >> hosts.conf && echo "export NS_LOCAL_IP=$NS_LOCAL_IP" >> .bashrc'
+    bash -c 'echo "$CONF_FILE" >> hosts.conf && \
+    echo "export NS_LOCAL_IP=$NS_LOCAL_IP" >> .bashrc &&
+    echo "SendEnv RUST_BACKTRACE" >> ~/.ssh/config
+    ';
 for WORKER_IP in ${WORKER_IPS[@]}
 do
     docker exec docker_ns_master_1 bash -c "ssh-keyscan ${WORKER_IP} >> ~/.ssh/known_hosts"

--- a/docker/testing_cluster.sh
+++ b/docker/testing_cluster.sh
@@ -2,8 +2,8 @@
 SCRIPT_PATH=`dirname $(readlink -f $0)`
 cd $SCRIPT_PATH
 
-# Deploy a testing cluster with one master and 3 workers
-docker-compose up --scale ns_worker=3 -d 
+# Deploy a testing cluster with one master and 2 workers
+docker-compose up --scale ns_worker=2 -d 
 
 # Since we can't resolved domains yet, we have to get each container IP to create the config file
 WORKER_IPS=$(docker-compose ps | grep -oE "docker_ns_worker_[0-9]+" \

--- a/src/cache_tracker.rs
+++ b/src/cache_tracker.rs
@@ -102,12 +102,12 @@ impl CacheTracker {
         //            self.master_ip, self.master_port
         //        );
         let shuffle_id_bytes = bincode::serialize(&message).unwrap();
-        let mut message = ::capnp::message::Builder::new_default();
+        let mut message = capnp::message::Builder::new_default();
         let mut shuffle_data = message.init_root::<serialized_data::Builder>();
         shuffle_data.set_msg(&shuffle_id_bytes);
         serialize_packed::write_message(&mut stream, &message).unwrap();
 
-        let r = ::capnp::message::ReaderOptions {
+        let r = capnp::message::ReaderOptions {
             traversal_limit_in_words: std::u64::MAX,
             nesting_limit: 64,
         };
@@ -141,7 +141,7 @@ impl CacheTracker {
                             let slave_usage = slave_usage.clone();
                             thread::spawn(move || {
                                 //reading
-                                let r = ::capnp::message::ReaderOptions {
+                                let r = capnp::message::ReaderOptions {
                                     traversal_limit_in_words: std::u64::MAX,
                                     nesting_limit: 64,
                                 };
@@ -259,7 +259,7 @@ impl CacheTracker {
                                     _ => CacheTrackerMessageReply::Ok,
                                 };
                                 let result = bincode::serialize(&reply).unwrap();
-                                let mut message = ::capnp::message::Builder::new_default();
+                                let mut message = capnp::message::Builder::new_default();
                                 let mut locs_data = message.init_root::<serialized_data::Builder>();
                                 locs_data.set_msg(&result);
                                 serialize_packed::write_message(&mut stream, &message).unwrap();

--- a/src/context.rs
+++ b/src/context.rs
@@ -85,7 +85,11 @@ pub struct Context {
 impl Drop for Context {
     fn drop(&mut self) {
         //TODO clean up temp files
-        log::debug!("inside context drop in master {}", self.distributed_master);
+        if self.distributed_master {
+            log::trace!("inside context drop in master");
+        } else {
+            log::trace!("inside context drop in executor");
+        }
         self.drop_executors();
     }
 }
@@ -223,7 +227,7 @@ impl Context {
     fn init_distributed_worker() -> Result<!> {
         let uuid = Uuid::new_v4().to_string();
         initialize_loggers(format!("/tmp/executor-{}", uuid));
-        log::debug!("started client");
+        log::debug!("starting worker");
         let port = env::Configuration::get()
             .slave
             .as_ref()

--- a/src/dependency.rs
+++ b/src/dependency.rs
@@ -162,21 +162,21 @@ impl<K: Data + Eq + Hash, V: Data, C: Data> ShuffleDependencyTrait for ShuffleDe
     }
 
     fn do_shuffle_task(&self, rdd_base: Arc<dyn RddBase>, partition: usize) -> String {
-        log::debug!("doing shuffle_task for partition {}", partition);
+        log::debug!("executing shuffle task for partition #{}", partition);
         let split = rdd_base.splits()[partition].clone();
         let aggregator = self.aggregator.clone();
         let num_output_splits = self.partitioner.get_num_of_partitions();
-        log::debug!("is cogroup rdd{}", self.is_cogroup);
-        log::debug!("num of output splits{}", num_output_splits);
+        log::debug!("is cogroup rdd: {}", self.is_cogroup);
+        log::debug!("number of output splits: {}", num_output_splits);
         let partitioner = self.partitioner.clone();
         let mut buckets: Vec<HashMap<K, C>> = (0..num_output_splits)
             .map(|_| HashMap::new())
             .collect::<Vec<_>>();
         log::debug!(
-            "before rdd base iterator in shuffle map task for partition {}",
+            "before iterating while executing shuffle map task for partition #{}",
             partition
         );
-        log::debug!("split index {}", split.get_index());
+        log::debug!("split index: {}", split.get_index());
 
         let iter = if self.is_cogroup {
             rdd_base.cogroup_iterator_any(split)
@@ -189,7 +189,7 @@ impl<K: Data + Eq + Hash, V: Data, C: Data> ShuffleDependencyTrait for ShuffleDe
             let (k, v) = *b;
             if count == 0 {
                 log::debug!(
-                    "iterator inside dependency map task after downcasting {:?} {:?}",
+                    "iterating inside dependency map task after downcasting: key: {:?}, value: {:?}",
                     k,
                     v
                 );
@@ -209,11 +209,11 @@ impl<K: Data + Eq + Hash, V: Data, C: Data> ShuffleDependencyTrait for ShuffleDe
             let set: Vec<(K, C)> = bucket.into_iter().collect();
             let ser_bytes = bincode::serialize(&set).unwrap();
             log::debug!(
-                "shuffle dependency map task set in shuffle id, partition,i  {:?} {:?} {:?} {:?} ",
-                set.get(0),
+                "shuffle dependency map task set from bucket #{} in shuffle id #{}, partition #{}: {:?}",
+                i,
                 self.shuffle_id,
                 partition,
-                i
+                set.get(0)
             );
             env::SHUFFLE_CACHE.insert((self.shuffle_id, partition, i), ser_bytes);
         }

--- a/src/distributed_scheduler.rs
+++ b/src/distributed_scheduler.rs
@@ -6,7 +6,6 @@ use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc,
 };
-use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::dag_scheduler::{CompletionEvent, TastEndReason};
@@ -265,13 +264,13 @@ impl NativeScheduler for DistributedScheduler {
 
             let task_bytes = bincode::serialize(&ser_task).unwrap();
             log::debug!(
-                "task in executor {} {:?} master",
-                target_executor.port(),
-                ser_task.get_task_id()
+                "sending task {} to {} executor",
+                ser_task.get_task_id(),
+                target_executor.port()
             );
             let mut stream = TcpStream::connect(&target_executor).unwrap();
             log::debug!(
-                "task in executor {} {} master task len",
+                "sending task to {} executor, bytes length: {}",
                 target_executor.port(),
                 task_bytes.len()
             );
@@ -291,9 +290,9 @@ impl NativeScheduler for DistributedScheduler {
                 .get_root::<serialized_data::Reader>()
                 .unwrap();
             log::debug!(
-                "task in executor {} {} master task result len",
-                target_executor.port(),
-                task_data.get_msg().unwrap().len()
+                "received task result of {} bytes from executor @{}",
+                task_data.get_msg().unwrap().len(),
+                target_executor.port()
             );
             let result: TaskResult = bincode::deserialize(&task_data.get_msg().unwrap()).unwrap();
             match ser_task {

--- a/src/distributed_scheduler.rs
+++ b/src/distributed_scheduler.rs
@@ -76,7 +76,7 @@ impl DistributedScheduler {
         port: u16,
     ) -> Self {
         log::debug!(
-            "starting distributed scheduler @ port {} (in master mode {})",
+            "starting distributed scheduler @ port {} (in master mode: {})",
             port,
             master,
         );
@@ -279,7 +279,8 @@ impl DistributedScheduler {
                 .get_root::<serialized_data::Reader>()
                 .unwrap();
             log::debug!(
-                "received task result of {} bytes from executor @{}",
+                "received task #{} result of {} bytes from executor @{}",
+                task.get_task_id(),
                 task_data.get_msg().unwrap().len(),
                 target_port
             );
@@ -390,7 +391,6 @@ impl NativeScheduler for DistributedScheduler {
                                 target_executor.port(),
                             )
                             .await;
-                            log::debug!("received response from exec @{}", target_executor.port());
                         });
                         break;
                     }

--- a/src/distributed_scheduler.rs
+++ b/src/distributed_scheduler.rs
@@ -367,9 +367,9 @@ impl NativeScheduler for DistributedScheduler {
                             );
 
                             // send incoming message size to executor
-                            let msg_len = u64::to_le_bytes(buf.len() as u64);
+                            let msg_size = u64::to_le_bytes(buf.len() as u64);
                             writter
-                                .write_all(&msg_len)
+                                .write_all(&msg_size)
                                 .await
                                 .map_err(Error::OutputWrite)
                                 .unwrap();

--- a/src/distributed_scheduler.rs
+++ b/src/distributed_scheduler.rs
@@ -93,7 +93,7 @@ impl DistributedScheduler {
             shuffle_to_map_stage: Arc::new(DashMap::new()),
             cache_locs: Arc::new(DashMap::new()),
             master,
-            framework_name: "spark".to_string(),
+            framework_name: "native_spark".to_string(),
             is_registered: true, //TODO check if it is necessary
             active_jobs: HashMap::new(),
             active_job_queue: Vec::new(),
@@ -171,7 +171,7 @@ impl DistributedScheduler {
             self_borrow.submit_stage(jt.final_stage.clone(), jt.clone());
             utils::yield_tokio_futures();
             log::debug!(
-                "pending stages and tasks {:?}",
+                "pending stages and tasks: {:?}",
                 jt.pending_tasks
                     .lock()
                     .iter()
@@ -192,7 +192,7 @@ impl DistributedScheduler {
                         .unwrap()
                         .clone();
                     log::debug!(
-                        "removing stage task from pending tasks {} {}",
+                        "removing stage #{} task from pending task #{}",
                         stage.id,
                         evt.task.get_task_id()
                     );

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,31 +1,23 @@
+use std::fs;
 use std::net::Ipv4Addr;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use self::config_vars::*;
 use crate::cache::BoundedMemoryCache;
 use crate::cache_tracker::CacheTracker;
+use crate::error::Error;
 use crate::hosts::Hosts;
 use crate::map_output_tracker::MapOutputTracker;
 use crate::shuffle::{ShuffleFetcher, ShuffleManager};
-use clap::{App, Arg, SubCommand};
 use dashmap::DashMap;
-use log::LevelFilter as LogLevel;
+use log::LevelFilter;
 use once_cell::sync::{Lazy, OnceCell};
-use thiserror::Error;
+use serde::{Deserialize, Serialize};
 use tokio::runtime::{Handle, Runtime};
 
 type ShuffleCache = Arc<DashMap<(usize, usize, usize), Vec<u8>>>;
 
-pub(crate) mod config_vars {
-    pub const DEPLOYMENT_MODE: &str = "NS_DEPLOYMENT_MODE";
-    pub const LOCAL_DIR: &str = "NS_LOCAL_DIR";
-    pub const LOCAL_IP: &str = "NS_LOCAL_IP";
-    pub const LOG_LEVEL: &str = "NS_LOG_LEVEL";
-    pub const PORT: &str = "NS_PORT";
-    pub const SHUFFLE_SERVICE_PORT: &str = "NS_SHUFFLE_SERVICE_PORT";
-}
-
+const ENV_VAR_PREFIX: &str = "NS_";
 pub(crate) const THREAD_PREFIX: &str = "_NS";
 static CONF: OnceCell<Configuration> = OnceCell::new();
 static ENV: OnceCell<Env> = OnceCell::new();
@@ -42,22 +34,6 @@ pub(crate) struct Env {
     async_rt: Option<Runtime>,
 }
 
-/// Builds an async executor for executing DAG tasks according to env,
-/// machine properties and schedulling mode.
-fn build_async_executor() -> Option<Runtime> {
-    if Handle::try_current().is_ok() {
-        None
-    } else {
-        Some(
-            tokio::runtime::Builder::new()
-                .enable_all()
-                .threaded_scheduler()
-                .build()
-                .unwrap(),
-        )
-    }
-}
-
 impl Env {
     pub fn get() -> &'static Env {
         ENV.get_or_init(Self::new)
@@ -69,6 +45,22 @@ impl Env {
             executor.handle()
         } else {
             &ASYNC_HANDLE
+        }
+    }
+
+    /// Builds an async executor for executing DAG tasks according to env,
+    /// machine properties and schedulling mode.
+    fn build_async_executor() -> Option<Runtime> {
+        if Handle::try_current().is_ok() {
+            None
+        } else {
+            Some(
+                tokio::runtime::Builder::new()
+                    .enable_all()
+                    .threaded_scheduler()
+                    .build()
+                    .unwrap(),
+            )
         }
     }
 
@@ -85,144 +77,166 @@ impl Env {
                 conf.local_ip,
                 &BOUNDED_MEM_CACHE,
             ),
-            async_rt: build_async_executor(),
+            async_rt: Env::build_async_executor(),
         }
     }
 }
 
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum LogLevel {
+    Error,
+    Warn,
+    Debug,
+    Trace,
+    Info,
+}
+
+impl Into<LevelFilter> for LogLevel {
+    fn into(self) -> LevelFilter {
+        match self {
+            LogLevel::Error => LevelFilter::Error,
+            LogLevel::Warn => LevelFilter::Warn,
+            LogLevel::Debug => LevelFilter::Debug,
+            LogLevel::Trace => LevelFilter::Trace,
+            _ => LevelFilter::Info,
+        }
+    }
+}
+
+/// Struct used for parsing environment vars
+#[derive(Deserialize, Debug)]
+struct EnvConfig {
+    deployment_mode: Option<DeploymentMode>,
+    local_ip: Option<String>,
+    local_dir: Option<String>,
+    log_level: Option<LogLevel>,
+    shuffle_service_port: Option<u16>,
+    slave_deployment: Option<bool>,
+    slave_port: Option<u16>,
+}
+
+#[derive(Clone, Copy, PartialEq, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum DeploymentMode {
     Distributed,
     Local,
 }
 
-pub(crate) const SLAVE_DEPLOY_CMD: &str = "deploy_slave";
-
+#[derive(Serialize, Deserialize, Clone)]
 pub(crate) struct Configuration {
     pub is_master: bool,
     pub local_ip: Ipv4Addr,
     pub local_dir: PathBuf,
-    pub port: Option<u16>,
     pub deployment_mode: DeploymentMode,
     pub log_level: LogLevel,
     pub shuffle_svc_port: Option<u16>,
+    pub slave: Option<SlaveConfig>,
 }
 
-impl Configuration {
-    pub fn get() -> &'static Configuration {
-        CONF.get_or_init(Self::new)
+#[derive(Serialize, Deserialize, Clone)]
+pub(crate) struct SlaveConfig {
+    pub deployment: bool,
+    pub port: u16,
+}
+
+impl From<(bool, u16)> for SlaveConfig {
+    fn from(config: (bool, u16)) -> Self {
+        let (deployment, port) = config;
+        SlaveConfig { deployment, port }
     }
+}
 
-    fn new() -> Self {
-        let arguments = App::new("NativeSpark")
-            .arg(
-                Arg::with_name(DEPLOYMENT_MODE)
-                    .long("deployment_mode")
-                    .short("d")
-                    .takes_value(true)
-                    .env(DEPLOYMENT_MODE)
-                    .default_value("local"),
-            )
-            .arg(
-                Arg::with_name(LOCAL_IP)
-                    .long("local_ip")
-                    .require_equals(true)
-                    .env(LOCAL_IP)
-                    .takes_value(true)
-                    .required_if(DEPLOYMENT_MODE, "distributed")
-                    .default_value_if(
-                        DEPLOYMENT_MODE,
-                        Some("local"),
-                        &Ipv4Addr::LOCALHOST.to_string(),
-                    ),
-            )
-            .arg(Arg::with_name(LOCAL_DIR).long("local_dir").env(LOCAL_DIR))
-            .arg(
-                Arg::with_name(LOG_LEVEL)
-                    .long("log_level")
-                    .env(LOG_LEVEL)
-                    .takes_value(true)
-                    .require_equals(true),
-            )
-            .arg(
-                Arg::with_name(SHUFFLE_SERVICE_PORT)
-                    .long("shuffle.port")
-                    .env(SHUFFLE_SERVICE_PORT),
-            )
-            .subcommand(
-                SubCommand::with_name(SLAVE_DEPLOY_CMD)
-                    .about("deploys an slave at the executing machine")
-                    .arg(
-                        Arg::with_name(PORT)
-                            .long("port")
-                            .short("p")
-                            .env(PORT)
-                            .takes_value(true)
-                            .require_equals(true)
-                            .required(true),
-                    ),
-            )
-            .get_matches();
+impl Default for Configuration {
+    fn default() -> Self {
+        use DeploymentMode::*;
 
-        let deployment_mode = match arguments.value_of(DEPLOYMENT_MODE) {
-            Some("distributed") => DeploymentMode::Distributed,
-            _ => DeploymentMode::Local,
+        // this may be a worker, try to get conf dynamically from file:
+        if let Some(config) = Configuration::get_from_file() {
+            return config;
+        }
+
+        let config = envy::prefixed(ENV_VAR_PREFIX)
+            .from_env::<EnvConfig>()
+            .unwrap();
+
+        let deployment_mode = match config.deployment_mode {
+            Some(Distributed) => Distributed,
+            _ => Local,
         };
 
-        let local_dir = if let Some(dir) = arguments.value_of(LOCAL_DIR) {
-            PathBuf::from(dir.to_owned())
+        let local_dir = if let Some(dir) = config.local_dir {
+            PathBuf::from(dir)
         } else {
             std::env::temp_dir()
         };
 
-        let log_level = match arguments
-            .value_of(LOG_LEVEL)
-            .map(|s| s.to_lowercase())
-            .as_deref()
-        {
-            Some("error") => LogLevel::Error,
-            Some("warn") => LogLevel::Warn,
-            Some("debug") => LogLevel::Debug,
-            Some("trace") => LogLevel::Trace,
+        let log_level = match config.log_level {
+            Some(val) => val,
             _ => LogLevel::Info,
         };
-        log::set_max_level(log_level);
+        log::set_max_level(log_level.into());
 
-        let local_ip = arguments.value_of(LOCAL_IP).unwrap().parse().unwrap();
-        let port: Option<u16>;
+        let local_ip: Ipv4Addr = {
+            if let Some(ip) = config.local_ip {
+                ip.parse().unwrap()
+            } else if deployment_mode == Distributed {
+                panic!("Local IP required while deploying in distributed mode.")
+            } else {
+                Ipv4Addr::LOCALHOST
+            }
+        };
+
         let is_master;
-        if let Some(slave_deployment) = arguments.subcommand_matches(SLAVE_DEPLOY_CMD) {
-            port = Some(
-                slave_deployment
-                    .value_of(PORT)
-                    .unwrap()
-                    .parse()
-                    .map_err(ConfigurationError::PortParsing)
-                    .unwrap(),
-            );
-            is_master = false;
-        } else {
-            port = None;
-            is_master = true;
+        let slave: Option<SlaveConfig>;
+        match config.slave_deployment {
+            Some(true) => {
+                if let Some(port) = config.slave_port {
+                    is_master = false;
+                    slave = Some(SlaveConfig {
+                        deployment: true,
+                        port,
+                    });
+                } else {
+                    panic!("Port required while deploying a worker.")
+                }
+            }
+            _ => {
+                is_master = true;
+                slave = None;
+            }
         }
+
         Configuration {
             is_master,
             local_ip,
             local_dir,
-            port,
             deployment_mode,
             log_level,
-            shuffle_svc_port: arguments.value_of(SHUFFLE_SERVICE_PORT).map(|port| {
-                port.parse()
-                    .map_err(ConfigurationError::PortParsing)
-                    .unwrap()
-            }),
+            shuffle_svc_port: config.shuffle_service_port,
+            slave,
         }
     }
 }
 
-#[derive(Debug, Error)]
-pub enum ConfigurationError {
-    #[error("failed to parse port")]
-    PortParsing(#[source] std::num::ParseIntError),
+impl Configuration {
+    pub fn get() -> &'static Configuration {
+        CONF.get_or_init(Self::default)
+    }
+
+    fn get_from_file() -> Option<Configuration> {
+        let binary_path = std::env::current_exe()
+            .map_err(|_| Error::CurrentBinaryPath)
+            .unwrap();
+        if let Some(dir) = binary_path.parent() {
+            let conf_file = dir.join("config.toml");
+            if conf_file.exists() {
+                return fs::read_to_string(conf_file)
+                    .map(|content| toml::from_str::<Configuration>(&content).ok())
+                    .ok()
+                    .flatten();
+            }
+        }
+        None
+    }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -82,7 +82,7 @@ impl Env {
     }
 }
 
-#[derive(Serialize, Deserialize, Clone, Copy, Debug)]
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum LogLevel {
     Error,
@@ -175,6 +175,7 @@ impl Default for Configuration {
             Some(val) => val,
             _ => LogLevel::Info,
         };
+        log::debug!("Setting max log level to: {:?}", log_level);
         log::set_max_level(log_level.into());
 
         let local_ip: Ipv4Addr = {

--- a/src/env.rs
+++ b/src/env.rs
@@ -68,11 +68,11 @@ impl Env {
         let conf = Configuration::get();
         let master_addr = Hosts::get().unwrap().master;
         Env {
-            map_output_tracker: MapOutputTracker::new(conf.is_master, master_addr),
+            map_output_tracker: MapOutputTracker::new(conf.is_driver, master_addr),
             shuffle_manager: ShuffleManager::new().unwrap(),
             shuffle_fetcher: ShuffleFetcher,
             cache_tracker: CacheTracker::new(
-                conf.is_master,
+                conf.is_driver,
                 master_addr,
                 conf.local_ip,
                 &BOUNDED_MEM_CACHE,
@@ -125,7 +125,7 @@ pub enum DeploymentMode {
 
 #[derive(Serialize, Deserialize, Clone)]
 pub(crate) struct Configuration {
-    pub is_master: bool,
+    pub is_driver: bool,
     pub local_ip: Ipv4Addr,
     pub local_dir: PathBuf,
     pub deployment_mode: DeploymentMode,
@@ -209,7 +209,7 @@ impl Default for Configuration {
         }
 
         Configuration {
-            is_master,
+            is_driver: is_master,
             local_ip,
             local_dir,
             deployment_mode,

--- a/src/env.rs
+++ b/src/env.rs
@@ -124,6 +124,16 @@ pub enum DeploymentMode {
     Local,
 }
 
+impl DeploymentMode {
+    pub fn is_local(self) -> bool {
+        if let DeploymentMode::Local = self {
+            true
+        } else {
+            false
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone)]
 pub(crate) struct Configuration {
     pub is_driver: bool,

--- a/src/env.rs
+++ b/src/env.rs
@@ -92,6 +92,16 @@ pub(crate) enum LogLevel {
     Info,
 }
 
+impl LogLevel {
+    pub fn is_debug_or_lower(self) -> bool {
+        use LogLevel::*;
+        match self {
+            Debug | Trace => true,
+            _ => false,
+        }
+    }
+}
+
 impl Into<LevelFilter> for LogLevel {
     fn into(self) -> LevelFilter {
         match self {

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -66,6 +66,7 @@ impl Executor {
                     return Err(Error::ExecutorShutdown);
                 }
                 let self_clone = Arc::clone(&self);
+                log::debug!("received new task @{} executor", self.port);
                 tokio::spawn(async move {
                     let mut buf: Vec<u8> = Vec::new();
                     let mut reader = BufReader::new(stream);
@@ -102,7 +103,7 @@ impl Executor {
             .get_root::<serialized_data::Reader>()
             .unwrap();
         log::debug!(
-            "task in executor {} {} slave task len",
+            "serialized task @{} executor with {} bytes",
             self.port,
             task_data.get_msg().unwrap().len()
         );
@@ -118,11 +119,11 @@ impl Executor {
         // let mut f = fs::File::create(task_dir_path.clone()).unwrap();
         let msg = match task_data.get_msg() {
             Ok(s) => {
-                log::debug!("got the task in executor",);
+                log::debug!("got the task message in executor {}", self.port);
                 s
             }
             Err(e) => {
-                log::debug!("problem in getting the task in executor {:?}", e);
+                log::debug!("problem while getting the task in executor: {:?}", e);
                 std::process::exit(0);
             }
         };
@@ -134,13 +135,9 @@ impl Executor {
         // f.read(&mut buffer).unwrap();
         let des_task: TaskOption = bincode::deserialize(&msg)?;
         log::debug!(
-            "task in executor {:?} {} slave task id",
+            "deserialized task at executor @{} with id {}, deserialziation took {} ms",
             self.port,
             des_task.get_task_id(),
-        );
-        log::debug!(
-            "time taken in server for deserializing:{} {}",
-            self.port,
             start.elapsed().as_millis(),
         );
         Ok(des_task)

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -76,7 +76,6 @@ impl Executor {
                 _ => {}
             }
             log::debug!("received new task @{} executor", self.port);
-            log::debug!("inside executor tp running task");
             let message = {
                 let message_reader = {
                     if let Some(data) =
@@ -108,15 +107,16 @@ impl Executor {
         self: &Arc<Self>,
         message_reader: CpnpReader<OwnedSegments>,
     ) -> Result<TaskOption> {
+        let start = Instant::now();
         let task_data = message_reader
             .get_root::<serialized_data::Reader>()
             .unwrap();
         log::debug!(
-            "deserialized task @{} executor with {} bytes",
+            "deserialized data task @{} executor with {} bytes, took {}ms",
             self.port,
-            task_data.get_msg().unwrap().len()
+            task_data.get_msg().unwrap().len(),
+            start.elapsed().as_millis()
         );
-        let start = Instant::now();
         // let local_dir_root = "/tmp";
         // let uuid = Uuid::new_v4();
         // let local_dir_uuid = uuid.to_string();
@@ -142,9 +142,10 @@ impl Executor {
         // let mut f = fs::File::open(task_dir_path).unwrap();
         // let mut buffer = vec![0; msg.len()];
         // f.read(&mut buffer).unwrap();
+        let start = Instant::now();
         let des_task: TaskOption = bincode::deserialize(&msg)?;
         log::debug!(
-            "deserialized task at executor @{} with id {}, deserialization took {}ms",
+            "deserialized task at executor @{} with id #{}, deserialization, took {}ms",
             self.port,
             des_task.get_task_id(),
             start.elapsed().as_millis(),
@@ -168,7 +169,7 @@ impl Executor {
             let start = Instant::now();
             let result = bincode::serialize(&result)?;
             log::debug!(
-                "time taken @{} executor serializing task #{} result of size {}: {}ms",
+                "time taken @{} executor serializing task #{} result of size {} bytes: {}ms",
                 self.port,
                 des_task.get_task_id(),
                 result.len(),

--- a/src/local_scheduler.rs
+++ b/src/local_scheduler.rs
@@ -7,7 +7,6 @@ use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc,
 };
-use std::thread;
 use std::time::{Duration, Instant};
 
 use crate::dag_scheduler::{CompletionEvent, TastEndReason};

--- a/src/local_scheduler.rs
+++ b/src/local_scheduler.rs
@@ -17,7 +17,7 @@ use crate::job::{Job, JobTracker};
 use crate::map_output_tracker::MapOutputTracker;
 use crate::rdd::{Rdd, RddBase};
 use crate::result_task::ResultTask;
-use crate::scheduler::NativeScheduler;
+use crate::scheduler::{EventQueue, NativeScheduler};
 use crate::serializable_traits::{Data, SerFunc};
 use crate::shuffle::ShuffleMapTask;
 use crate::stage::Stage;
@@ -32,7 +32,7 @@ pub struct LocalScheduler {
     attempt_id: Arc<AtomicUsize>,
     resubmit_timeout: u128,
     poll_timeout: u64,
-    event_queues: Arc<DashMap<usize, VecDeque<CompletionEvent>>>,
+    event_queues: EventQueue,
     pub(crate) next_job_id: Arc<AtomicUsize>,
     next_run_id: Arc<AtomicUsize>,
     next_task_id: Arc<AtomicUsize>,

--- a/src/local_scheduler.rs
+++ b/src/local_scheduler.rs
@@ -122,7 +122,7 @@ impl LocalScheduler {
             self_borrow.submit_stage(jt.final_stage.clone(), jt.clone());
             utils::yield_tokio_futures();
             log::debug!(
-                "pending stages and tasks {:?}",
+                "pending stages and tasks: {:?}",
                 jt.pending_tasks
                     .lock()
                     .iter()
@@ -143,7 +143,7 @@ impl LocalScheduler {
                         .unwrap()
                         .clone();
                     log::debug!(
-                        "removing stage task from pending tasks {} {}",
+                        "removing stage #{} task from pending task #{}",
                         stage.id,
                         evt.task.get_task_id()
                     );

--- a/src/map_output_tracker.rs
+++ b/src/map_output_tracker.rs
@@ -59,12 +59,12 @@ impl MapOutputTracker {
         }
         let mut stream = TcpStream::connect(self.master_addr).unwrap();
         let shuffle_id_bytes = bincode::serialize(&shuffle_id).unwrap();
-        let mut message = ::capnp::message::Builder::new_default();
+        let mut message = capnp::message::Builder::new_default();
         let mut shuffle_data = message.init_root::<serialized_data::Builder>();
         shuffle_data.set_msg(&shuffle_id_bytes);
         serialize_packed::write_message(&mut stream, &message).unwrap();
 
-        let r = ::capnp::message::ReaderOptions {
+        let r = capnp::message::ReaderOptions {
             traversal_limit_in_words: std::u64::MAX,
             nesting_limit: 64,
         };
@@ -106,7 +106,7 @@ impl MapOutputTracker {
                             let server_uris_clone = server_uris.clone();
                             thread::spawn(move || {
                                 //reading
-                                let r = ::capnp::message::ReaderOptions {
+                                let r = capnp::message::ReaderOptions {
                                     traversal_limit_in_words: std::u64::MAX,
                                     nesting_limit: 64,
                                 };
@@ -143,7 +143,7 @@ impl MapOutputTracker {
 
                                 //writing
                                 let result = bincode::serialize(&locs).unwrap();
-                                let mut message = ::capnp::message::Builder::new_default();
+                                let mut message = capnp::message::Builder::new_default();
                                 let mut locs_data = message.init_root::<serialized_data::Builder>();
                                 locs_data.set_msg(&result);
                                 serialize_packed::write_message(&mut stream, &message).unwrap();

--- a/src/map_output_tracker.rs
+++ b/src/map_output_tracker.rs
@@ -5,9 +5,14 @@ use std::thread;
 use std::time;
 
 use crate::serialized_data_capnp::serialized_data;
-use capnp::serialize_packed;
+use capnp::{message::ReaderOptions, serialize_packed};
 use dashmap::DashMap;
 use parking_lot::{Mutex, RwLock};
+
+const CAPNP_BUF_READ_OPTS: ReaderOptions = ReaderOptions {
+    traversal_limit_in_words: std::u64::MAX,
+    nesting_limit: 64,
+};
 
 pub enum MapOutputTrackerMessage {
     //contains shuffle_id
@@ -15,7 +20,7 @@ pub enum MapOutputTrackerMessage {
     StopMapOutputTracker,
 }
 
-// starts the server in master node and client in slave nodes. Similar to cache tracker
+// Starts the server in master node and client in slave nodes. Similar to cache tracker.
 #[derive(Clone, Debug)]
 pub(crate) struct MapOutputTracker {
     is_master: bool,
@@ -52,42 +57,26 @@ impl MapOutputTracker {
     }
 
     fn client(&self, shuffle_id: usize) -> Vec<String> {
-        //        if !self.is_master {
-
-        while let Err(_) = TcpStream::connect(self.master_addr) {
-            continue;
-        }
-        let mut stream = TcpStream::connect(self.master_addr).unwrap();
+        let mut stream = loop {
+            match TcpStream::connect(self.master_addr) {
+                Ok(stream) => break stream,
+                Err(_) => continue,
+            }
+        };
         let shuffle_id_bytes = bincode::serialize(&shuffle_id).unwrap();
         let mut message = capnp::message::Builder::new_default();
         let mut shuffle_data = message.init_root::<serialized_data::Builder>();
         shuffle_data.set_msg(&shuffle_id_bytes);
         serialize_packed::write_message(&mut stream, &message).unwrap();
 
-        let r = capnp::message::ReaderOptions {
-            traversal_limit_in_words: std::u64::MAX,
-            nesting_limit: 64,
-        };
         let mut stream_r = std::io::BufReader::new(&mut stream);
-        let message_reader = serialize_packed::read_message(&mut stream_r, r).unwrap();
+        let message_reader =
+            serialize_packed::read_message(&mut stream_r, CAPNP_BUF_READ_OPTS).unwrap();
         let shuffle_data = message_reader
             .get_root::<serialized_data::Reader>()
             .unwrap();
         let locs: Vec<String> = bincode::deserialize(&shuffle_data.get_msg().unwrap()).unwrap();
         locs
-        //        }
-        //        else {
-        //
-        //            let locs = self
-        //                .server_uris
-        //                .read()
-        //                .unwrap()
-        //                .get(&shuffle_id)
-        //                .unwrap_or(&Vec::new())
-        //                .clone();
-        //            let locs = locs.into_iter().map(|x| x.unwrap()).collect::<Vec<_>>();
-        //            return locs;
-        //        }
     }
 
     fn server(&self) {
@@ -136,7 +125,7 @@ impl MapOutputTracker {
                                 let locs = server_uris_clone
                                     .get(&shuffle_id)
                                     .map(|kv| kv.value().clone())
-                                    .unwrap_or(Vec::new());
+                                    .unwrap_or_default();
                                 log::debug!("locs inside mapoutput tracker server before unwrapping for shuffle id {:?} {:?}",shuffle_id,locs);
                                 let locs = locs.into_iter().map(|x| x.unwrap()).collect::<Vec<_>>();
                                 log::debug!("locs inside mapoutput tracker server after unwrapping for shuffle id {:?} {:?} ", shuffle_id, locs);
@@ -167,35 +156,25 @@ impl MapOutputTracker {
     }
 
     pub fn register_map_output(&self, shuffle_id: usize, map_id: usize, server_uri: String) {
-        //        if !self.is_master {
-        //            return;
-        //        }
+        log::debug!(
+            "registering map output from shuffle task #{} with map id #{} at server: {}",
+            shuffle_id,
+            map_id,
+            server_uri
+        );
         self.server_uris.get_mut(&shuffle_id).unwrap()[map_id] = Some(server_uri);
     }
 
     pub fn register_map_outputs(&self, shuffle_id: usize, locs: Vec<Option<String>>) {
-        //        if !self.is_master {
-        //            let fetched = self.client(shuffle_id);
-        //            println!("fetched locs from client {:?}", fetched);
-        //            self.server_uris.write().insert(
-        //                shuffle_id,
-        //                fetched.iter().map(|x| Some(x.clone())).collect(),
-        //            );
-        //            return;
-        //        }
         log::debug!(
-            "registering map outputs inside map output tracker for shuffle id {} {:?}",
+            "registering map outputs inside map output tracker for shuffle id #{}: {:?}",
             shuffle_id,
             locs
         );
         self.server_uris.insert(shuffle_id, locs);
-        //        .insert(shuffle_id, locs.into_iter().map(|x| Some(x)).collect());
     }
 
     pub fn unregister_map_output(&self, shuffle_id: usize, map_id: usize, server_uri: String) {
-        //        if !self.is_master {
-        //            return;
-        //        }
         let array = self.server_uris.get(&shuffle_id);
         if let Some(arr) = array {
             if arr.get(map_id).unwrap() == &Some(server_uri) {
@@ -212,7 +191,8 @@ impl MapOutputTracker {
 
     pub fn get_server_uris(&self, shuffle_id: usize) -> Vec<String> {
         log::debug!(
-            "server uris inside get_server_uris method {:?}",
+            "trying to get uri for shuffle task #{}, current server uris: {:?}",
+            shuffle_id,
             self.server_uris
         );
         if self
@@ -225,46 +205,34 @@ impl MapOutputTracker {
             .next()
             .is_none()
         {
-            // if self.server_uris.read().get(&shuffle_id).is_empty(){
             if self.fetching.read().contains(&shuffle_id) {
                 while self.fetching.read().contains(&shuffle_id) {
                     //check whether this will hurt the performance or not
                     let wait = time::Duration::from_millis(1);
                     thread::sleep(wait);
                 }
-                log::debug!(
-                    "returning after fetching done {:?}",
-                    self.server_uris
-                        .get(&shuffle_id)
-                        .unwrap()
-                        .iter()
-                        .filter(|x| !x.is_none())
-                        .map(|x| x.clone().unwrap())
-                        .collect::<Vec<_>>()
-                );
-                return self
+                let servers = self
                     .server_uris
                     .get(&shuffle_id)
                     .unwrap()
                     .iter()
                     .filter(|x| !x.is_none())
                     .map(|x| x.clone().unwrap())
-                    .collect();
+                    .collect::<Vec<_>>();
+                log::debug!("returning after fetching done, return: {:?}", servers);
+                return servers;
             } else {
                 log::debug!("adding to fetching queue");
                 self.fetching.write().insert(shuffle_id);
             }
-            // TODO logging
             let fetched = self.client(shuffle_id);
-            log::debug!("fetched locs from client {:?}", fetched);
+            log::debug!("fetched locs from client: {:?}", fetched);
             self.server_uris.insert(
                 shuffle_id,
                 fetched.iter().map(|x| Some(x.clone())).collect(),
             );
-            log::debug!("wriiten to server_uris after fetching");
+            log::debug!("added locs to server uris after fetching");
             self.fetching.write().remove(&shuffle_id);
-            log::debug!("returning from get server uri");
-
             fetched
         } else {
             self.server_uris

--- a/src/rdd/cartesian_rdd.rs
+++ b/src/rdd/cartesian_rdd.rs
@@ -76,7 +76,7 @@ impl<T: Data, U: Data> RddBase for CartesianRdd<T, U> {
     }
 
     fn get_context(&self) -> Arc<Context> {
-        self.vals.context.clone()
+        self.vals.context.upgrade().unwrap()
     }
 
     fn get_dependencies(&self) -> Vec<Dependency> {

--- a/src/rdd/co_grouped_rdd.rs
+++ b/src/rdd/co_grouped_rdd.rs
@@ -144,7 +144,7 @@ impl<K: Data + Eq + Hash> RddBase for CoGroupedRdd<K> {
     }
 
     fn get_context(&self) -> Arc<Context> {
-        self.vals.context.clone()
+        self.vals.context.upgrade().unwrap()
     }
 
     fn get_dependencies(&self) -> Vec<Dependency> {

--- a/src/rdd/co_grouped_rdd.rs
+++ b/src/rdd/co_grouped_rdd.rs
@@ -213,10 +213,10 @@ impl<K: Data + Eq + Hash> Rdd for CoGroupedRdd<K> {
             for (dep_num, dep) in split.clone().deps.into_iter().enumerate() {
                 match dep {
                     CoGroupSplitDep::NarrowCoGroupSplitDep { rdd, split } => {
-                        log::debug!("inside iterator cogrouprdd  narrow dep");
+                        log::debug!("inside iterator CoGroupedRdd narrow dep");
                         for i in rdd.iterator_any(split)? {
                             log::debug!(
-                                "inside iterator cogrouprdd  narrow dep iterator any {:?}",
+                                "inside iterator CoGroupedRdd narrow dep iterator any: {:?}",
                                 i
                             );
                             let b = i
@@ -231,7 +231,7 @@ impl<K: Data + Eq + Hash> Rdd for CoGroupedRdd<K> {
                         }
                     }
                     CoGroupSplitDep::ShuffleCoGroupSplitDep { shuffle_id } => {
-                        log::debug!("inside iterator cogrouprdd  shuffle dep agg {:?}", agg);
+                        log::debug!("inside iterator CoGroupedRdd shuffle dep, agg: {:?}", agg);
                         let num_rdds = self.rdds.len();
                         let agg_clone = agg.clone();
                         let merge_pair = move |(k, c): (K, Vec<Box<dyn AnyData>>)| {

--- a/src/rdd/coalesced_rdd.rs
+++ b/src/rdd/coalesced_rdd.rs
@@ -164,7 +164,7 @@ impl<T: Data> RddBase for CoalescedRdd<T> {
     }
 
     fn get_context(&self) -> Arc<Context> {
-        self.vals.context.clone()
+        self.vals.context.upgrade().unwrap()
     }
 
     fn get_dependencies(&self) -> Vec<Dependency> {

--- a/src/rdd/flatmap_rdd.rs
+++ b/src/rdd/flatmap_rdd.rs
@@ -64,7 +64,7 @@ where
     }
 
     fn get_context(&self) -> Arc<Context> {
-        self.vals.context.clone()
+        self.vals.context.upgrade().unwrap()
     }
 
     fn get_dependencies(&self) -> Vec<Dependency> {

--- a/src/rdd/map_partitions_rdd.rs
+++ b/src/rdd/map_partitions_rdd.rs
@@ -73,7 +73,7 @@ where
     }
 
     fn get_context(&self) -> Arc<Context> {
-        self.vals.context.clone()
+        self.vals.context.upgrade().unwrap()
     }
 
     fn get_dependencies(&self) -> Vec<Dependency> {

--- a/src/rdd/mapper_rdd.rs
+++ b/src/rdd/mapper_rdd.rs
@@ -74,7 +74,7 @@ where
     }
 
     fn get_context(&self) -> Arc<Context> {
-        self.vals.context.clone()
+        self.vals.context.upgrade().unwrap()
     }
 
     fn get_dependencies(&self) -> Vec<Dependency> {

--- a/src/rdd/pair_rdd.rs
+++ b/src/rdd/pair_rdd.rs
@@ -251,7 +251,7 @@ where
         &self,
         split: Box<dyn Split>,
     ) -> Result<Box<dyn Iterator<Item = Box<dyn AnyData>>>> {
-        log::debug!("inside iterator_any mapvaluesrdd",);
+        log::debug!("inside iterator_any mapvaluesrdd");
         Ok(Box::new(
             self.iterator(split)?
                 .map(|(k, v)| Box::new((k, v)) as Box<dyn AnyData>),
@@ -261,7 +261,7 @@ where
         &self,
         split: Box<dyn Split>,
     ) -> Result<Box<dyn Iterator<Item = Box<dyn AnyData>>>> {
-        log::debug!("inside iterator_any mapvaluesrdd",);
+        log::debug!("inside cogroup_iterator_any mapvaluesrdd");
         Ok(Box::new(self.iterator(split)?.map(|(k, v)| {
             Box::new((k, Box::new(v) as Box<dyn AnyData>)) as Box<dyn AnyData>
         })))

--- a/src/rdd/pair_rdd.rs
+++ b/src/rdd/pair_rdd.rs
@@ -235,7 +235,7 @@ where
         self.vals.id
     }
     fn get_context(&self) -> Arc<Context> {
-        self.vals.context.clone()
+        self.vals.context.upgrade().unwrap()
     }
     fn get_dependencies(&self) -> Vec<Dependency> {
         self.vals.dependencies.clone()
@@ -347,7 +347,7 @@ where
         self.vals.id
     }
     fn get_context(&self) -> Arc<Context> {
-        self.vals.context.clone()
+        self.vals.context.upgrade().unwrap()
     }
     fn get_dependencies(&self) -> Vec<Dependency> {
         self.vals.dependencies.clone()

--- a/src/rdd/partitionwise_sampled_rdd.rs
+++ b/src/rdd/partitionwise_sampled_rdd.rs
@@ -62,7 +62,7 @@ impl<T: Data> RddBase for PartitionwiseSampledRdd<T> {
     }
 
     fn get_context(&self) -> Arc<Context> {
-        self.vals.context.clone()
+        self.vals.context.upgrade().unwrap()
     }
 
     fn get_dependencies(&self) -> Vec<Dependency> {

--- a/src/rdd/partitionwise_sampled_rdd.rs
+++ b/src/rdd/partitionwise_sampled_rdd.rs
@@ -109,7 +109,7 @@ impl<T: Data, V: Data> RddBase for PartitionwiseSampledRdd<(T, V)> {
         &self,
         split: Box<dyn Split>,
     ) -> Result<Box<dyn Iterator<Item = Box<dyn AnyData>>>> {
-        log::debug!("inside iterator_any maprdd",);
+        log::debug!("inside PartitionwiseSampledRdd cogroup_iterator_any",);
         Ok(Box::new(self.iterator(split)?.map(|(k, v)| {
             Box::new((k, Box::new(v) as Box<dyn AnyData>)) as Box<dyn AnyData>
         })))

--- a/src/rdd/rdd.rs
+++ b/src/rdd/rdd.rs
@@ -4,7 +4,7 @@ use std::hash::Hash;
 use std::io::{BufWriter, Write};
 use std::net::Ipv4Addr;
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use crate::context::Context;
 use crate::dependency::Dependency;
@@ -47,12 +47,12 @@ pub use union_rdd::*;
 
 // Values which are needed for all RDDs
 #[derive(Serialize, Deserialize)]
-pub struct RddVals {
+pub(crate) struct RddVals {
     pub id: usize,
     pub dependencies: Vec<Dependency>,
     should_cache: bool,
     #[serde(skip_serializing, skip_deserializing)]
-    pub context: Arc<Context>,
+    pub context: Weak<Context>,
 }
 
 impl RddVals {
@@ -61,7 +61,7 @@ impl RddVals {
             id: sc.new_rdd_id(),
             dependencies: Vec::new(),
             should_cache: false,
-            context: sc,
+            context: Arc::downgrade(&sc),
         }
     }
 

--- a/src/rdd/shuffled_rdd.rs
+++ b/src/rdd/shuffled_rdd.rs
@@ -93,7 +93,7 @@ impl<K: Data + Eq + Hash, V: Data, C: Data> RddBase for ShuffledRdd<K, V, C> {
     }
 
     fn get_context(&self) -> Arc<Context> {
-        self.vals.context.upgrade().unwrap().clone()
+        self.vals.context.upgrade().unwrap()
     }
 
     fn get_dependencies(&self) -> Vec<Dependency> {

--- a/src/rdd/shuffled_rdd.rs
+++ b/src/rdd/shuffled_rdd.rs
@@ -62,8 +62,9 @@ impl<K: Data + Eq + Hash, V: Data, C: Data> ShuffledRdd<K, V, C> {
         aggregator: Arc<Aggregator<K, V, C>>,
         part: Box<dyn Partitioner>,
     ) -> Self {
-        let mut vals = RddVals::new(parent.get_context());
-        let shuffle_id = vals.context.new_shuffle_id();
+        let ctx = parent.get_context();
+        let shuffle_id = ctx.new_shuffle_id();
+        let mut vals = RddVals::new(ctx);
 
         vals.dependencies
             .push(Dependency::ShuffleDependency(Arc::new(
@@ -92,7 +93,7 @@ impl<K: Data + Eq + Hash, V: Data, C: Data> RddBase for ShuffledRdd<K, V, C> {
     }
 
     fn get_context(&self) -> Arc<Context> {
-        self.vals.context.clone()
+        self.vals.context.upgrade().unwrap().clone()
     }
 
     fn get_dependencies(&self) -> Vec<Dependency> {

--- a/src/rdd/union_rdd.rs
+++ b/src/rdd/union_rdd.rs
@@ -200,8 +200,8 @@ impl<T: Data> RddBase for UnionRdd<T> {
 
     fn get_context(&self) -> Arc<Context> {
         match &self.0 {
-            NonUniquePartitioner { vals, .. } => vals.context.clone(),
-            PartitionerAware { vals, .. } => vals.context.clone(),
+            NonUniquePartitioner { vals, .. } => vals.context.upgrade().unwrap(),
+            PartitionerAware { vals, .. } => vals.context.upgrade().unwrap(),
         }
     }
 

--- a/src/rdd/zip_rdd.rs
+++ b/src/rdd/zip_rdd.rs
@@ -56,7 +56,7 @@ impl<F: Data, S: Data> RddBase for ZippedPartitionsRdd<F, S> {
     }
 
     fn get_context(&self) -> Arc<Context> {
-        self.vals.context.clone()
+        self.vals.context.upgrade().unwrap()
     }
 
     fn get_dependencies(&self) -> Vec<Dependency> {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -96,7 +96,7 @@ pub(crate) trait NativeScheduler {
             missing.iter().map(|x| x.id).collect::<Vec<_>>()
         );
         log::debug!(
-            "visisted stages {:?}",
+            "visited stages {:?}",
             visited.iter().map(|x| x.get_rdd_id()).collect::<Vec<_>>()
         );
         if !visited.contains(&rdd) {
@@ -146,7 +146,7 @@ pub(crate) trait NativeScheduler {
             parents.iter().map(|x| x.id).collect::<Vec<_>>()
         );
         log::debug!(
-            "visisted stages {:?}",
+            "visited stages {:?}",
             visited.iter().map(|x| x.get_rdd_id()).collect::<Vec<_>>()
         );
         if !visited.contains(&rdd) {
@@ -339,7 +339,7 @@ pub(crate) trait NativeScheduler {
     where
         F: SerFunc((TaskContext, Box<dyn Iterator<Item = T>>)) -> U,
     {
-        log::debug!("submiting stage {}", stage.id);
+        log::debug!("submitting stage {}", stage.id);
         if !jt.waiting.lock().contains(&stage) && !jt.running.lock().contains(&stage) {
             let missing = self.get_missing_parent_stages(stage.clone());
             log::debug!(

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -34,6 +34,8 @@ pub trait Scheduler {
     fn default_parallelism(&self) -> i64;
 }
 
+pub(crate) type EventQueue = Arc<DashMap<usize, VecDeque<CompletionEvent>>>;
+
 /// Functionality by the library built-in schedulers
 pub(crate) trait NativeScheduler {
     /// Fast path for execution. Runs the DD in the driver main thread if possible.
@@ -393,7 +395,7 @@ pub(crate) trait NativeScheduler {
                     TaskOption::ResultTask(Box::new(result_task)),
                     id_in_job,
                     executor,
-                );
+                )
             }
         } else {
             for p in 0..stage.num_partitions {

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -104,7 +104,7 @@ pub(crate) trait NativeScheduler {
             // TODO CacheTracker register
             for _ in 0..rdd.number_of_splits() {
                 let locs = self.get_cache_locs(rdd.clone());
-                log::debug!("cache locs {:?}", locs);
+                log::debug!("cache locs: {:?}", locs);
                 if locs == None {
                     for dep in rdd.get_dependencies() {
                         log::debug!("for dep in missing stages ");
@@ -400,7 +400,7 @@ pub(crate) trait NativeScheduler {
                 log::debug!("shuffle_stage {}", stage.id);
                 if stage.output_locs[p].is_empty() {
                     let locs = self.get_preferred_locs(stage.get_rdd(), p);
-                    log::debug!("creating task for {} partition  {}", stage.id, p);
+                    log::debug!("creating task for {} partition {}", stage.id, p);
                     let shuffle_map_task = ShuffleMapTask::new(
                         self.get_next_task_id(),
                         jt.run_id,
@@ -411,7 +411,7 @@ pub(crate) trait NativeScheduler {
                         locs,
                     );
                     log::debug!(
-                        "creating task for {} partition  {} and shuffle id {}",
+                        "creating task for stage {}, partition {} and shuffle id {}",
                         stage.id,
                         p,
                         shuffle_map_task.dep.get_shuffle_id()

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -62,12 +62,12 @@ pub(crate) trait NativeScheduler {
         rdd_base: Arc<dyn RddBase>,
         shuffle_dependency: Option<Arc<dyn ShuffleDependencyTrait>>,
     ) -> Stage {
-        log::debug!("inside new stage");
+        log::debug!("creating new stage");
         env::Env::get()
             .cache_tracker
             .register_rdd(rdd_base.get_rdd_id(), rdd_base.number_of_splits());
         if shuffle_dependency.is_some() {
-            log::debug!("shuffle dependency and registering mapoutput tracker");
+            log::debug!("shuffle dependency exists, registering to map output tracker");
             self.register_shuffle(
                 shuffle_dependency.clone().unwrap().get_shuffle_id(),
                 rdd_base.number_of_splits(),
@@ -75,7 +75,7 @@ pub(crate) trait NativeScheduler {
             log::debug!("new stage tracker after");
         }
         let id = self.get_next_stage_id();
-        log::debug!("new stage id {}", id);
+        log::debug!("new stage id #{}", id);
         let stage = Stage::new(
             id,
             rdd_base.clone(),
@@ -83,7 +83,7 @@ pub(crate) trait NativeScheduler {
             self.get_parent_stages(rdd_base),
         );
         self.insert_into_stage_cache(id, stage.clone());
-        log::debug!("new stage stage return");
+        log::debug!("returning new stage #{}", id);
         stage
     }
 
@@ -94,11 +94,11 @@ pub(crate) trait NativeScheduler {
         rdd: Arc<dyn RddBase>,
     ) {
         log::debug!(
-            "missing stages {:?}",
+            "missing stages: {:?}",
             missing.iter().map(|x| x.id).collect::<Vec<_>>()
         );
         log::debug!(
-            "visited stages {:?}",
+            "visited stages: {:?}",
             visited.iter().map(|x| x.get_rdd_id()).collect::<Vec<_>>()
         );
         if !visited.contains(&rdd) {
@@ -113,17 +113,17 @@ pub(crate) trait NativeScheduler {
                         match dep {
                             Dependency::ShuffleDependency(shuf_dep) => {
                                 let stage = self.get_shuffle_map_stage(shuf_dep.clone());
-                                log::debug!("shuffle stage in missing stages {:?}", stage.id);
+                                log::debug!("shuffle stage #{} in missing stages", stage.id);
                                 if !stage.is_available() {
                                     log::debug!(
-                                        "inserting shuffle stage in missing stages {:?}",
+                                        "inserting shuffle stage #{} in missing stages",
                                         stage.id
                                     );
                                     missing.insert(stage);
                                 }
                             }
                             Dependency::NarrowDependency(nar_dep) => {
-                                log::debug!("narrow stage in missing stages ");
+                                log::debug!("narrow stage in missing stages");
                                 self.visit_for_missing_parent_stages(
                                     missing,
                                     visited,
@@ -144,11 +144,11 @@ pub(crate) trait NativeScheduler {
         rdd: Arc<dyn RddBase>,
     ) {
         log::debug!(
-            "parent stages {:?}",
+            "parent stages: {:?}",
             parents.iter().map(|x| x.id).collect::<Vec<_>>()
         );
         log::debug!(
-            "visited stages {:?}",
+            "visited stages: {:?}",
             visited.iter().map(|x| x.get_rdd_id()).collect::<Vec<_>>()
         );
         if !visited.contains(&rdd) {
@@ -175,7 +175,7 @@ pub(crate) trait NativeScheduler {
         let mut visited: BTreeSet<Arc<dyn RddBase>> = BTreeSet::new();
         self.visit_for_parent_stages(&mut parents, &mut visited, rdd.clone());
         log::debug!(
-            "parent stages {:?}",
+            "parent stages: {:?}",
             parents.iter().map(|x| x.id).collect::<Vec<_>>()
         );
         parents.into_iter().collect()
@@ -241,21 +241,22 @@ pub(crate) trait NativeScheduler {
                 *num_finished += 1;
             }
         } else if let Ok(smt) = completed_event.task.downcast::<ShuffleMapTask>() {
-            let result = completed_event
+            let shuffle_server_uri = completed_event
                 .result
                 .take()
                 .unwrap()
                 .downcast_ref::<String>()
                 .unwrap()
                 .clone();
-
-            log::debug!("result inside queue {:?}", result);
-            self.add_output_loc_to_stage(smt.stage_id, smt.partition, result);
+            log::debug!(
+                "completed shuffle task server uri: {:?}",
+                shuffle_server_uri
+            );
+            self.add_output_loc_to_stage(smt.stage_id, smt.partition, shuffle_server_uri);
 
             let stage = self.fetch_from_stage_cache(smt.stage_id);
-            // id_to_stage.lock().clone()[&smt.stage_id].clone();
             log::debug!(
-                "pending stages {:?}",
+                "pending stages: {:?}",
                 jt.pending_tasks
                     .lock()
                     .iter()
@@ -263,7 +264,7 @@ pub(crate) trait NativeScheduler {
                     .collect::<Vec<_>>()
             );
             log::debug!(
-                "pending tasks {:?}",
+                "pending tasks: {:?}",
                 jt.pending_tasks
                     .lock()
                     .get(&stage)
@@ -273,23 +274,23 @@ pub(crate) trait NativeScheduler {
                     .collect::<Vec<_>>()
             );
             log::debug!(
-                "running {:?}",
+                "running stages: {:?}",
                 jt.running.lock().iter().map(|x| x.id).collect::<Vec<_>>()
             );
             log::debug!(
-                "waiting {:?}",
+                "waiting stages: {:?}",
                 jt.waiting.lock().iter().map(|x| x.id).collect::<Vec<_>>()
             );
 
             if jt.running.lock().contains(&stage)
                 && jt.pending_tasks.lock().get(&stage).unwrap().is_empty()
             {
-                log::debug!("here before registering map outputs ");
+                log::debug!("started registering map outputs");
                 //TODO logging
                 jt.running.lock().remove(&stage);
                 if stage.shuffle_dependency.is_some() {
                     log::debug!(
-                        "stage output locs before register mapoutput tracker {:?}",
+                        "stage output locs before register mapoutput tracker: {:?}",
                         stage.output_locs
                     );
                     let locs = stage
@@ -298,7 +299,7 @@ pub(crate) trait NativeScheduler {
                         .map(|x| x.get(0).map(|s| s.to_owned()))
                         .collect();
                     log::debug!(
-                        "locs for shuffle id {:?} {:?}",
+                        "locs for shuffle id #{}: {:?}",
                         stage.clone().shuffle_dependency.unwrap().get_shuffle_id(),
                         locs
                     );
@@ -306,14 +307,14 @@ pub(crate) trait NativeScheduler {
                         stage.shuffle_dependency.unwrap().get_shuffle_id(),
                         locs,
                     );
-                    log::debug!("here after registering map outputs ");
+                    log::debug!("finished registering map outputs");
                 }
                 //TODO Cache
                 self.update_cache_locs();
                 let mut newly_runnable = Vec::new();
                 for stage in jt.waiting.lock().iter() {
                     log::debug!(
-                        "waiting stage parent stages for stage {} are {:?}",
+                        "waiting stage parent stages for stage #{} are: {:?}",
                         stage.id,
                         self.get_missing_parent_stages(stage.clone())
                             .iter()
@@ -341,11 +342,12 @@ pub(crate) trait NativeScheduler {
     where
         F: SerFunc((TaskContext, Box<dyn Iterator<Item = T>>)) -> U,
     {
-        log::debug!("submitting stage {}", stage.id);
+        log::debug!("submitting stage #{}", stage.id);
         if !jt.waiting.lock().contains(&stage) && !jt.running.lock().contains(&stage) {
             let missing = self.get_missing_parent_stages(stage.clone());
             log::debug!(
-                "inside submit stage missing stages {:?}",
+                "while submitting stage #{}, missing stages: {:?}",
+                stage.id,
                 missing.iter().map(|x| x.id).collect::<Vec<_>>()
             );
             if missing.is_empty() {
@@ -369,7 +371,7 @@ pub(crate) trait NativeScheduler {
             .entry(stage.clone())
             .or_insert_with(BTreeSet::new);
         if stage == jt.final_stage {
-            log::debug!("final stage {}", stage.id);
+            log::debug!("final stage #{}", stage.id);
             for (id_in_job, (id, part)) in jt
                 .output_parts
                 .iter()
@@ -399,10 +401,10 @@ pub(crate) trait NativeScheduler {
             }
         } else {
             for p in 0..stage.num_partitions {
-                log::debug!("shuffle_stage {}", stage.id);
+                log::debug!("shuffle stage #{}", stage.id);
                 if stage.output_locs[p].is_empty() {
                     let locs = self.get_preferred_locs(stage.get_rdd(), p);
-                    log::debug!("creating task for {} partition {}", stage.id, p);
+                    log::debug!("creating task for stage #{} partition #{}", stage.id, p);
                     let shuffle_map_task = ShuffleMapTask::new(
                         self.get_next_task_id(),
                         jt.run_id,
@@ -413,7 +415,7 @@ pub(crate) trait NativeScheduler {
                         locs,
                     );
                     log::debug!(
-                        "creating task for stage {}, partition {} and shuffle id {}",
+                        "creating task for stage #{}, partition #{} and shuffle id #{}",
                         stage.id,
                         p,
                         shuffle_map_task.dep.get_shuffle_id()
@@ -596,7 +598,7 @@ macro_rules! impl_common_scheduler_funcs {
         }
 
         fn get_missing_parent_stages(&self, stage: Stage) -> Vec<Stage> {
-            log::debug!("inside get missing parent stages");
+            log::debug!("getting missing parent stages");
             let mut missing: BTreeSet<Stage> = BTreeSet::new();
             let mut visited: BTreeSet<Arc<dyn RddBase>> = BTreeSet::new();
             self.visit_for_missing_parent_stages(&mut missing, &mut visited, stage.get_rdd());
@@ -604,7 +606,7 @@ macro_rules! impl_common_scheduler_funcs {
         }
 
         fn get_shuffle_map_stage(&self, shuf: Arc<dyn ShuffleDependencyTrait>) -> Stage {
-            log::debug!("inside get_shufflemap stage");
+            log::debug!("getting shuffle map stage");
             let stage = self
                 .shuffle_to_map_stage
                 .get(&shuf.get_shuffle_id())
@@ -612,11 +614,11 @@ macro_rules! impl_common_scheduler_funcs {
             match stage {
                 Some(stage) => stage,
                 None => {
-                    log::debug!("inside get_shufflemap stage before");
+                    log::debug!("started creating shuffle map stage before");
                     let stage = self.new_stage(shuf.get_rdd_base(), Some(shuf.clone()));
                     self.shuffle_to_map_stage
                         .insert(shuf.get_shuffle_id(), stage.clone());
-                    log::debug!("inside get_shufflemap return");
+                    log::debug!("finished inserting newly created shuffle stage");
                     stage
                 }
             }

--- a/src/shuffle/shuffle_manager.rs
+++ b/src/shuffle/shuffle_manager.rs
@@ -93,11 +93,7 @@ impl ShuffleManager {
             ShuffleManager::launch_async_server(bind_ip, bind_port)?;
             bind_port
         };
-        let server_uri = format!(
-            "http://{}:{}",
-            env::Configuration::get().local_ip.clone(),
-            port,
-        );
+        let server_uri = format!("http://{}:{}", env::Configuration::get().local_ip, port,);
         log::debug!("server_uri {:?}", server_uri);
         Ok(server_uri)
     }
@@ -192,7 +188,6 @@ impl ShuffleManager {
                 log::debug!("creating directory at path: {:?}", &local_dir);
                 fs::create_dir_all(&local_dir)
                     .map_err(|_| ShuffleError::CouldNotCreateShuffleDir)?;
-                log::debug!("local_dir path: {:?}", local_dir);
                 return Ok(local_dir);
             }
         }

--- a/src/shuffle/shuffle_manager.rs
+++ b/src/shuffle/shuffle_manager.rs
@@ -230,7 +230,13 @@ impl ShuffleService {
             }
             Ok(parts) => parts,
         };
-        if let Some(cached_data) = env::SHUFFLE_CACHE.get(&(parts[0], parts[1], parts[2])) {
+        let params = &(parts[0], parts[1], parts[2]);
+        if let Some(cached_data) = env::SHUFFLE_CACHE.get(params) {
+            log::debug!(
+                "got a request @ `{}`, params: {:?}, returning data",
+                uri,
+                params
+            );
             Ok(Vec::from(&cached_data[..]))
         } else {
             Err(ShuffleError::RequestedCacheNotFound)

--- a/src/shuffle/shuffle_manager.rs
+++ b/src/shuffle/shuffle_manager.rs
@@ -337,7 +337,7 @@ mod tests {
         for _ in 0..parallelism {
             let manager = manager.clone();
             threads.push(thread::spawn(move || -> Result<()> {
-                for _ in 0..1_000 {
+                for _ in 0..10 {
                     match manager.check_status() {
                         Ok(StatusCode::OK) => {}
                         _ => return Err(ShuffleError::AsyncRuntimeError),

--- a/src/shuffle/shuffle_manager.rs
+++ b/src/shuffle/shuffle_manager.rs
@@ -181,9 +181,7 @@ impl ShuffleManager {
     fn get_local_work_dir() -> Result<PathBuf> {
         let local_dir_root = &env::Configuration::get().local_dir;
         for _ in 0..10 {
-            let uuid = Uuid::new_v4();
-            let local_dir_uuid = uuid.to_string();
-            let local_dir = local_dir_root.join(format!("spark-local-{}", local_dir_uuid));
+            let local_dir = local_dir_root.join(format!("ns-local-{}", Uuid::new_v4().to_string()));
             if !local_dir.exists() {
                 log::debug!("creating directory at path: {:?}", &local_dir);
                 fs::create_dir_all(&local_dir)

--- a/src/stage.rs
+++ b/src/stage.rs
@@ -78,7 +78,7 @@ impl Stage {
             true
         } else {
             log::debug!(
-                "num available outputs and num partitions in is available method in stage{} {:?}",
+                "num available outputs {}, and num partitions {}, in is available method in stage",
                 self.num_available_outputs,
                 self.num_partitions
             );
@@ -88,7 +88,7 @@ impl Stage {
 
     pub fn add_output_loc(&mut self, partition: usize, host: String) {
         log::debug!(
-            "adding loc for partition inside stage {} {:?}",
+            "adding loc for partition inside stage {} @{}",
             partition,
             host
         );

--- a/src/task.rs
+++ b/src/task.rs
@@ -96,11 +96,10 @@ impl From<ShuffleMapTask> for TaskOption {
 
 #[derive(Serialize, Deserialize)]
 pub enum TaskResult {
-    //    //    #[serde(with = "serde_traitobject")]
     ResultTask(serde_traitobject::Box<dyn serde_traitobject::Any + Send + Sync>),
     ShuffleTask(serde_traitobject::Box<dyn serde_traitobject::Any + Send + Sync>),
 }
-//
+
 impl TaskOption {
     pub fn run(&self, id: usize) -> TaskResult {
         match self {
@@ -108,18 +107,21 @@ impl TaskOption {
             TaskOption::ShuffleMapTask(tsk) => TaskResult::ShuffleTask(tsk.run(id)),
         }
     }
+
     pub fn get_task_id(&self) -> usize {
         match self {
             TaskOption::ResultTask(tsk) => tsk.get_task_id(),
             TaskOption::ShuffleMapTask(tsk) => tsk.get_task_id(),
         }
     }
+
     pub fn get_run_id(&self) -> usize {
         match self {
             TaskOption::ResultTask(tsk) => tsk.get_run_id(),
             TaskOption::ShuffleMapTask(tsk) => tsk.get_run_id(),
         }
     }
+
     pub fn get_stage_id(&self) -> usize {
         match self {
             TaskOption::ResultTask(tsk) => tsk.get_stage_id(),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -35,11 +35,23 @@ pub(crate) fn get_free_port() -> Result<u16, error::NetworkError> {
     }
     Err(error::NetworkError::FreePortNotFound(port, 100))
 }
-
 fn get_dynamic_port() -> u16 {
     const FIRST_DYNAMIC_PORT: u16 = 49152;
     const LAST_DYNAMIC_PORT: u16 = 65535;
     FIRST_DYNAMIC_PORT + rand::thread_rng().gen_range(0, LAST_DYNAMIC_PORT - FIRST_DYNAMIC_PORT)
+}
+
+/// Get an incomign IPC size in the system word size
+pub(crate) async fn get_message_size<R: tokio::io::AsyncReadExt + Unpin>(
+    receiver: &mut R,
+) -> error::Result<usize> {
+    let mut msg_size = [0u8; 8];
+    receiver
+        .read_exact(&mut msg_size)
+        .await
+        .map_err(error::Error::InputRead)?;
+    let msg_size_word = u64::from_le_bytes(msg_size);
+    Ok(msg_size_word as usize)
 }
 
 #[test]

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -41,19 +41,6 @@ fn get_dynamic_port() -> u16 {
     FIRST_DYNAMIC_PORT + rand::thread_rng().gen_range(0, LAST_DYNAMIC_PORT - FIRST_DYNAMIC_PORT)
 }
 
-/// Get an incoming IPC size in the system word size
-pub(crate) async fn get_message_size<R: tokio::io::AsyncReadExt + Unpin>(
-    receiver: &mut R,
-) -> error::Result<usize> {
-    let mut msg_size = [0u8; 8];
-    receiver
-        .read_exact(&mut msg_size)
-        .await
-        .map_err(error::Error::InputRead)?;
-    let msg_size_word = u64::from_le_bytes(msg_size);
-    Ok(msg_size_word as usize)
-}
-
 #[test]
 #[cfg(test)]
 fn test_randomize_in_place() {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -41,7 +41,7 @@ fn get_dynamic_port() -> u16 {
     FIRST_DYNAMIC_PORT + rand::thread_rng().gen_range(0, LAST_DYNAMIC_PORT - FIRST_DYNAMIC_PORT)
 }
 
-/// Get an incomign IPC size in the system word size
+/// Get an incoming IPC size in the system word size
 pub(crate) async fn get_message_size<R: tokio::io::AsyncReadExt + Unpin>(
     receiver: &mut R,
 ) -> error::Result<usize> {

--- a/src/utils/test_utils.rs
+++ b/src/utils/test_utils.rs
@@ -9,7 +9,7 @@ pub(crate) fn create_test_task<F>(func: F) -> ResultTask<u8, u8, F>
 where
     F: SerFunc((TaskContext, Box<dyn Iterator<Item = u8>>)) -> u8,
 {
-    let ctxt = Context::new().unwrap();
+    let ctxt = Context::with_mode(DeploymentMode::Local).unwrap();
     let rdd_f = Fn!(move |data: u8| -> u8 { data });
     let rdd = ctxt.parallelize(vec![0, 1, 2], 1).map(rdd_f);
     ResultTask::new(2, 0, 0, rdd.into(), Arc::new(func), 0, vec![], 0)

--- a/userGuide/src/chapter_1.md
+++ b/userGuide/src/chapter_1.md
@@ -52,7 +52,9 @@ examples just run them. In `local`:
 > cargo run --example make_rdd
 
 In `distributed`:
-> cargo run --example make_rdd -d distributed
+> export NS_DEPLOYMENT_MODE=distributed
+>
+> cargo run --example make_rdd
 
 ## Deploying with Docker
 
@@ -68,7 +70,7 @@ and deploying distributed mode on your local host. In order to use them:
 This will execute all the necessary steeps to to deploy a working network of containers where you can execute the tests. When finished you can attach a shell to the master and run the examples:
 ```doc
 $ docker exec -it docker_ns_master_1 bash
-$ ./make_rdd -d distributed
+$ ./make_rdd
 ```
 
 ## Setting execution mode
@@ -81,13 +83,10 @@ In your application you can set the execution mode (`local` or `distributed`) in
 
     let context = Context::with_mode(DeploymentMode::Local)?;
 ```
-2. Execute the application with the `deployment mode` argument set to one of the valid modes (e.g.: `./my_app -d distributed`)
-3. Set the DEPLOYMENT_MODE environment variable (e.g.: `DEPLOYMENT_MODE=local`
+2. Set the DEPLOYMENT_MODE environment variable (e.g.: `DEPLOYMENT_MODE=local`).
 
 ### Additional notes
 
-Since File readers are not done, you have to use manual file reading for now (like manually reading from S3 or hack around local files by distributing copies of all files to all machines and make rdd using filename list).
-
-Ctrl-C and panic handling are not done yet, so if there is some problem during runtime, executors won't shut down automatically and you will have to manually kill the processes.
-
-One of the limitations of current implementation is that the input and return types of all closures and all input to make_rdd should be owned data.
+* Depending on the source you intend to use you may have to write your own source reading rdd (like manually reading from S3) if it's not yet available.
+* Ctrl-C and panic handling are not compeltely done yet, so if there is a problem during runtime, executors won't shut down automatically and you will have to manually kill the processes.
+* One of the limitations of current implementation is that the input and return types of all closures and all input to make_rdd should be owned data.


### PR DESCRIPTION
- [x] The configuration is now handled via env vars and config files entirely, no more passing through arguments. This frees the CLI args for user provided args in case they want to use clap or any parsers and does not collide with cargo itself.
- [x] The config if propagated to the workers properly through a config file and loaded on the fly. Bonus: the same can be done in the master so persistence of configuration should be easy to implement (probably can be merged witht he hosts.conf file).
- [x] Fixed/improved distributed mode where asynchronous reading/writing from the socket traffic from/to driver/executor was not being handled properly (now is done thought the correct `read_exact` method and pointing the right msg size at both ends so communication between both ends is robust).
- [x] Fixing the disabled unit test in the executor (should be rather easy now with the other fix in place).
- [x] Adding the missing featured to graceful shutdown workers on failure or job ending (and finding out why is not shutting down properly).

There are a couple changes still I want to make:
- [ ] There still is a bug with shuffle manager async version where shuffle jobs are not working properly
