### PR TITLE
add macros feature to tokio to support tokio::select! in executor.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ simplelog = "0.7.4"
 thiserror = "1.0.13"
 threadpool = "1.7.1"
 toml = "0.5.6"
-tokio = { version = "^0.2", features = ["rt-threaded", "stream", "sync", "time"] }
+tokio = { version = "^0.2", features = ["rt-threaded", "stream", "sync", "time", "macros"] }
 tokio-util = { version = "0.3.1", features = ["compat"] }
 uuid = { version = "0.8", features = ["v4"] }
 regex = "1.3.6"


### PR DESCRIPTION
Ran into the following compiler bug while testing an example.

```
error[E0433]: failed to resolve: could not find `select` in `tokio`
  --> /Users/lumost/workspace/native_spark/src/executor.rs:49:24
   |
49 |                 tokio::select! {
   |                        ^^^^^^ could not find `select` in `tokio`
```

Adding the macros feature to the tokio crate corrects this issue.